### PR TITLE
Add pyPDF2 to Text processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [xlwt](https://github.com/python-excel/xlwt) / [xlrd](https://github.com/python-excel/xlrd) - Packages is for writing and reading data and formatting information from Excel files.
     * [XlsxWriter](https://xlsxwriter.readthedocs.org/) - A Python module for creating Excel .xlsx files.
     * [PDFMiner](https://github.com/euske/pdfminer) - A tool for extracting information from PDF documents.
+    * [PyPDF2](https://github.com/mstamy2/PyPDF2) - a pure-python PDF library capable of splitting, merging and transforming PDF pages.
     * [Python-Markdown](https://github.com/waylan/Python-Markdown) - A Python implementation of John Gruber’s Markdown.
     * [Mistune](https://github.com/lepture/mistune) - Fastest and full featured pure Python parsers of Markdown.
     * [PyYAML](http://pyyaml.org/) - YAML implementations for Python.


### PR DESCRIPTION
pyPDF2 is under active maintenance and can be complementary to PDFMiner
