### PR TITLE
+WikiTeam tools for preserving wikis

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [youtube-dl](http://rg3.github.io/youtube-dl/) - A small command-line program to download videos from YouTube.
 * [you-get](http://www.soimort.org/you-get/) - A YouTube/Youku/Niconico video downloader written in Python 3.
 * [coursera](https://github.com/coursera-dl/coursera) - Script for downloading Coursera.org videos and naming them.
+* [WikiTeam](https://github.com/WikiTeam/wikiteam) - Tools for downloading and preserving wikis.
 
 ## Forms
 


### PR DESCRIPTION
Adding link to WikiTeam project, which has scripts for downloading wikis, mostly MediaWiki https://github.com/WikiTeam/wikiteam
