### PR TITLE
adding "cliff" for crafting multi-level command

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 
 * [click](http://click.pocoo.org/) - A package for creating beautiful command line interfaces in a composable way.
 * [clint](https://github.com/kennethreitz/clint) - Python Command-line Application Tools.
+* [cliff](https://cliff.readthedocs.org/en/latest/introduction.html) - A framework for creating command-line programs with multi-level commands 
 * [docopt](http://docopt.org/) - Pythonic command line arguments parser.
 * [colorama](https://pypi.python.org/pypi/colorama) - Cross-platform colored terminal text.
 


### PR DESCRIPTION
adding "cliff" for crafting multi-level command for command-line applications
doc_home: https://cliff.readthedocs.org/en/latest/introduction.html

from dev:

> The cliff framework is meant to be used to create multi-level commands such as subversion and git, where the main program handles some basic argument parsing and then invokes a sub-command to do the work.
