### PR TITLE
savory-pie Restful API Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [eve](https://github.com/nicolaiarocci/eve) - REST API framework powered by Flask, MongoDB and good intentions.
 * [sandman](https://github.com/jeffknupp/sandman) - Automated REST APIs for existing database-driven systems.
 * [restless](http://restless.readthedocs.org/en/latest/) - Framework agnostic REST framework based on lessons learned from TastyPie.
+* [savory-pie](https://github.com/RueLaLa/savory-pie/) - REST API building library (django, and others)
 
 ## Authentication and OAuth
 


### PR DESCRIPTION
Savory Pie is an API building library, we give you the pieces to build the API you need. Currently Django is the main target, but the only dependencies on Django are a single view and Resources and Fields that understand Django's ORM.
