### PR TITLE
Added pdoc api doc generator to Documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [reStructuredText](http://docutils.sourceforge.net/rst.html) - Markup Syntax and Parser Component of Docutils.
 * [MkDocs](http://www.mkdocs.org/) - Markdown friendly documentation generator.
 * [Pycco](http://fitzgen.github.io/pycco/) - The original quick-and-dirty, hundred-line-long, literate-programming-style documentation generator.
+* [pdoc](https://github.com/BurntSushi/pdoc) - Epydoc replacement to auto generate API documentation for Python libraries.
 
 ## Configuration
 


### PR DESCRIPTION
pdoc is a library and a command line program to discover the public interface of a Python module or package. The pdoc script can be used to generate plain text or HTML of a module's public interface, or it can be used to run an HTTP server that serves generated HTML for installed modules. It is intended that pdoc will be a replacement for the unmaintained epydoc. 
