### PR TITLE
Add WeChat Third-party API

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [gspread](https://github.com/burnash/gspread) - Google Spreadsheets Python API.
 * [facebook-sdk](https://github.com/pythonforfacebook/facebook-sdk) - Facebook Platform Python SDK.
 * [facepy](https://github.com/jgorset/facepy) - Facepy makes it really easy to interact with Facebook's Graph API
+* [WeChat](https://github.com/jerryling315/Pychat) - A WeChat Server-end's auto-reply written in Python web.py.
 * [Wikipedia](https://wikipedia.readthedocs.org/) - A Pythonic wrapper for the Wikipedia API.
 * [python-instagram](https://github.com/Instagram/python-instagram) - A Python Client for Instagram API.
 * [gmail](https://github.com/charlierguo/gmail) - A Pythonic interface for Gmail.


### PR DESCRIPTION
WeChat is one of the most popular IM app, this helps people to build a Service Account on the WeChat's Media Platform quickly
