### PR TITLE
Add noseOfYeti to the testing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,6 +781,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [contexts](https://github.com/benjamin-hodgson/Contexts) - A BDD framework for Python 3.3+. Inspired by C#'s `Machine.Specifications`.
     * [pyshould](https://github.com/drslump/pyshould) - Should style asserts based on [PyHamcrest](https://github.com/hamcrest/PyHamcrest).
     * [pyvows](http://heynemann.github.io/pyvows/) - BDD style testing for Python. Inspired by [Vows.js](http://vowsjs.org/).
+    * [noseOfYeti](https://noseofyeti.readthedocs.org) - A nose plugin that provides an RSpec inspired dsl for python 
 * Web Testing
     * [Selenium](https://pypi.python.org/pypi/selenium) - Python bindings for [Selenium](http://www.seleniumhq.org/) WebDriver.
     * [splinter](http://splinter.cobrateam.info/) - Open source tool for testing web applications.


### PR DESCRIPTION
NoseOfYeti is a nose plugin I made that provides an RSpec inspired dsl for python.
