### PR TITLE
Add stop-words, currencies, django-markwha, short_url, sanitize

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [python-readability](https://github.com/buriy/python-readability) - Fast Python port of arc90's readability tool.
 * [opengraph](https://github.com/erikriver/opengraph) - A Python module to parse the Open Graph Protocol
 * [textract](https://github.com/deanmalmgren/textract) - Extract text from any document, Word, PowerPoint, PDFs, etc.
+* [sanitize](https://github.com/Alir3z4/sanitize) - Bringing sanity to world of messed-up data.
 
 ## Forms
 


### PR DESCRIPTION
Add following awesome python packages:
- python-stop-words: Get list of common stop words in various languages in Python.
- python-currencies: Display money format and its filthy currencies, for all money lovers out there.
- django-markwhat: A collection of template filters that implement common markup languages.
- short_url: Python implementation for generating Tiny URL- and bit.ly-like URLs.
- sanitize: Bringing sanity to world of messed-up data.
