### PR TITLE
++ prompt-toolkit for CLI application

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,11 +269,14 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [colorama](https://pypi.python.org/pypi/colorama) - Cross-platform colored terminal text.
     * [pyCLI](https://pythonhosted.org/pyCLI/) - Command-line applications supporting standard command line parsing, logging, unit and functional testing.
     * [Gooey](https://github.com/chriskiehl/Gooey) - Turn command line programs into a full GUI application with one line
+    * * [prompt_toolkit](https://github.com/jonathanslenders/python-prompt-toolkit) - A Library for building powerful interactive command lines in Python. It ships with a nice interactive Python shell (called ptpython) built on top of the library.
+
 * Productivity Tools
     * [cookiecutter](https://github.com/audreyr/cookiecutter) - A command-line utility that creates projects from cookiecutters (project templates). E.g. Python package projects, jQuery plugin projects.
     * [httpie](https://github.com/jakubroztocil/httpie) - A command line HTTP client, a user-friendly cURL replacement.
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.
     * [RainbowStream](http://www.rainbowstream.org/) - Smart and nice Twitter client on terminal.
+    
 
 ## Downloader
 


### PR DESCRIPTION
prompt_toolkit is a Library for building powerful interactive command lines in Python. It ships with a nice interactive Python shell (called ptpython) built on top of the library.
