### PR TITLE
Add Sider: a persistent object library based on Redis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [MongoEngine](http://mongoengine.org/) - A Python Object-Document-Mapper for working with MongoDB.
     * [django-mongodb-engine](https://github.com/django-nonrel/mongodb-engine) - Django MongoDB Backend.
     * [redisco](https://github.com/kiddouk/redisco) - A Python Library for Simple Models and Containers Persisted in Redis.
+    * [Sider](https://sider.readthedocs.org) - A persistent object library based on Redis.
     * [flywheel](https://github.com/mathcamp/flywheel) - Object mapper for Amazon DynamoDB.
 * Others
     * [butterdb](https://github.com/Widdershin/butterdb) - A Python ORM for Google Drive Spreadsheets.


### PR DESCRIPTION
Added [Sider](https://sider.readthedocs.org).
