### PR TITLE
added virtualenv-mgr under Environment Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [virtualenv](https://pypi.python.org/pypi/virtualenv) - A tool to create isolated Python environments.
 * [virtualenvwrapper](https://pypi.python.org/pypi/virtualenvwrapper) - A set of extensions to virtualenv.
 * [virtualenv-api](https://github.com/sjkingo/virtualenv-api) - An API for virtualenv and pip.
+* [virtualenv-mgr](https://github.com/arteria/virtualenv-mgr) - A CLI to find virtualenvs and install/uninstall packages on multiple virtualenvs at once.
 * [pew](https://pypi.python.org/pypi/pew/) - A set of tools to manage multiple virtual environments.
 * [Vex](https://github.com/sashahart/vex) - Run a command in the named virtualenv.
 * [PyRun](https://www.egenix.com/products/python/PyRun/) - A one-file, no-installation-needed version of Python.


### PR DESCRIPTION
[virtualenv-mgr](https://github.com/arteria/virtualenv-mgr) is a CLI to manage multiple virtualenvs at once. The tool give you the ability to upgrade packages in all your projects and much more. 

I am not sure where to add it, Environment Management or Package Management. I have to put it under Environment Management because of the name of the tool.
