### PR TITLE
remove oauth2 as it is abandoned package

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,6 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [Authomatic](http://peterhudec.github.io/authomatic/) - Simple but powerful framework agnostic authentication/authorization client package.
     * [OAuthLib](https://github.com/idan/oauthlib) - A generic, spec-compliant, thorough implementation of the OAuth request-signing logic.
     * [rauth](https://github.com/litl/rauth) - A Python library for OAuth 1.0/a, 2.0, and Ofly.
-    * [python-oauth2](https://github.com/simplegeo/python-oauth2) - A fully tested, abstract interface to creating OAuth clients and servers.
     * [python-social-auth](https://github.com/omab/python-social-auth) - An easy-to-setup social authentication mechanism.
     * [django-oauth-toolkit](https://github.com/evonove/django-oauth-toolkit) - OAuth2 goodies for the Djangonauts.
     * [django-oauth2-provider](https://github.com/caffeinehit/django-oauth2-provider) - Providing OAuth2 access to Django app.


### PR DESCRIPTION
Please remove `oauth2`package from Authentication section. It's abandoned project https://github.com/simplegeo/python-oauth2 with no activity since 2011. 

It can't be an recommended awesome package as it is now. 
