### PR TITLE
Specify encoding explicitly

### DIFF
--- a/sort.py
+++ b/sort.py
@@ -15,8 +15,13 @@
 
 
 def main():
+    import sys
+    if sys.version_info.major == 2:
+        global open
+        from codecs import open
+        
     # First, we load the current README into memory as an array of lines
-    with open('README.md', 'r') as read_me_file:
+    with open('README.md', 'r', encoding = 'utf-8') as read_me_file:
         read_me = read_me_file.readlines()
 
     # Then we cluster the lines together as blocks
@@ -39,7 +44,7 @@ def main():
             blocks.append([line])
             last_indent = None
 
-    with open('README.md', 'w+') as sorted_file:
+    with open('README.md', 'w+', encoding = 'utf-8') as sorted_file:
         # Then all of the blocks are sorted individually
         blocks = [''.join(sorted(block, key=lambda s: s.lower())) for block in blocks]
         # And the result is written back to README.md


### PR DESCRIPTION
Since the default system encoding of my Win7 x64(simplified Chinese) is not utf-8, but GBK; sort.py doesn't work in Python 3.4.2. 

The traceback message is:

> Traceback (most recent call last):
>  File "E:\GitHub\sort.py", line 52, in <module>
>    main()
>  File "E:\GitHub\sort.py", line 22, in main
>    read_me = read_me_file.readlines()
> UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 6947: illegal multibyte sequence

So I just specify the encoding explicitly by passing the keyword argument  'encoding'. (Otherwise, Python 3.x will use the system's default encoding.)

The builtin 'open' function in Python 2.7.8 doesn't provide such a parameter, however. So I use codecs.open instead.

The modified version has already been tested on Win7 x64 with both Python 2.7.8 and Python 3.4.2.
