### PR TITLE
Add entry for Nuitka

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [py2app](http://pythonhosted.org/py2app/) - Freezes Python scripts (Mac OS X).
 * [PyInstaller](http://www.pyinstaller.org/) - Converts Python programs into stand-alone executables (cross-platform).
 * [dh-virtualenv](http://dh-virtualenv.readthedocs.org/) - Build and distribute a virtualenv as a Debian package.
+* [Nuitka](http://nuitka.net/) - Compile scripts, modules, packages to an executable or extension module.
 
 ## Build Tools
 


### PR DESCRIPTION
From [here](http://nuitka.net/pages/overview.html)

> Right now Nuitka is a good replacement for the Python interpreter and compiles every construct that CPython 2.6, 2.7, 3.2 and 3.3 offer. It translates the Python into a C++ program that then uses "libpython" to execute in the same way as CPython does, in a very compatible way.
