### PR TITLE
Fix cement URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 *Libraries for building command-line application.*
 
 * Command-line Application Development
-    * [cement](http://builtoncement.org/) - Cement provides a light-weight and fully featured foundation to build anything from single file scripts to complex and intricately designed applications.
+    * [cement](http://builtoncement.com/) - Cement provides a light-weight and fully featured foundation to build anything from single file scripts to complex and intricately designed applications.
     * [click](http://click.pocoo.org/) - A package for creating beautiful command line interfaces in a composable way.
     * [clint](https://github.com/kennethreitz/clint) - Python Command-line Application Tools.
     * [cliff](https://cliff.readthedocs.org/) - A framework for creating command-line programs with multi-level commands.


### PR DESCRIPTION
The cement Tool is found at builtoncement.com, not builtoncement.org. :-)
