### PR TITLE
Adding viper as PyPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [Warehouse](https://warehouse.python.org/)
 * [devpi](http://doc.devpi.net/) - PyPI server and packaging/testing/release tool.
 * [localshop](https://github.com/mvantellingen/localshop) - PyPI server which mirrors official packages on-demand, and also supports local (private) package uploads.
+* [viper](https://github.com/nestorsalceda/viper) - PyPI server designed for being ran in your own network, behind your firewall.
 
 ## Distribution
 


### PR DESCRIPTION
Adding [viper](https://github.com/nestorsalceda/viper) as PyPI server

/cc @nestorsalceda
