### PR TITLE
Add Pypsi

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [colorama](https://pypi.python.org/pypi/colorama) - Cross-platform colored terminal text.
     * [pyCLI](https://pythonhosted.org/pyCLI/) - Command-line applications supporting standard command line parsing, logging, unit and functional testing.
     * [Gooey](https://github.com/chriskiehl/Gooey) - Turn command line programs into a full GUI application with one line
+    * [Pypsi](http://ameily.github.io/pypsi) - Develop extensible and powerful command line interface shells with minimal code.
 * Productivity Tools
     * [cookiecutter](https://github.com/audreyr/cookiecutter) - A command-line utility that creates projects from cookiecutters (project templates). E.g. Python package projects, jQuery plugin projects.
     * [httpie](https://github.com/jakubroztocil/httpie) - A command line HTTP client, a user-friendly cURL replacement.


### PR DESCRIPTION
Add Pypsi, the Python Pluggable Shell Interface library. Develop extensible and powerful command line interface shells with minimal code and maximum reuse.
