### PR TITLE
Add joe

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [cookiecutter](https://github.com/audreyr/cookiecutter) - A command-line utility that creates projects from cookiecutters (project templates). E.g. Python package projects, jQuery plugin projects.
     * [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
     * [httpie](https://github.com/jakubroztocil/httpie) - A command line HTTP client, a user-friendly cURL replacement.
+    * [joe](https://github.com/karan/joe) - A .gitignore magician in your command line.
     * [PathPicker](https://github.com/facebook/PathPicker) - Select files out of bash output.
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.
     * [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.


### PR DESCRIPTION
Adding joe, the .gitignore magician,  to the Command-line Productivity
Tools section.
