### PR TITLE
Add SST (Selenium Simple Test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 
 * Debugger
     * [ipdb](https://pypi.python.org/pypi/ipdb) - IPython-enabled [pdb](https://docs.python.org/2/library/pdb.html).
+    * [pdb++](https://pypi.python.org/pypi/pdbpp) - Extension of the [pdb](https://docs.python.org/2/library/pdb.html) introduces a number of new features.
     * [pudb](https://pypi.python.org/pypi/pudb) – A full-screen, console-based Python debugger.
     * [pyringe](https://github.com/google/pyringe) - Debugger capable of attaching to and injecting code into Python processes.
     * [wdb](https://github.com/Kozea/wdb) - An improbable web debugger through WebSockets.

--- a/README.md
+++ b/README.md
@@ -861,6 +861,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [Robot Framework](https://github.com/robotframework/robotframework) - A generic test automation framework.
 * Web Testing
     * [Selenium](https://pypi.python.org/pypi/selenium) - Python bindings for [Selenium](http://www.seleniumhq.org/) WebDriver.
+    * [SST](http://testutils.org/sst) - Powerful set of [high-level functions](http://testutils.org/sst/actions.html) with clean and simple API for Selenium WebDriver.
     * [locust](https://github.com/locustio/locust) - Scalable user load testing tool written in Python.
     * [sixpack](https://github.com/seatgeek/sixpack) - A language-agnostic A/B Testing framework.
     * [splinter](https://splinter.readthedocs.org/en/latest/) - Open source tool for testing web applications.


### PR DESCRIPTION
Many of the "Selenium official" users writes own helpers in order to hiding low-level details of using Selenium API. SST provides many of such [helpers/actions](http://testutils.org/sst/actions.html) ensuring clean, simple and uniform API across all projects.