### PR TITLE
Add prettyconf in Configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [ConfigParser](https://docs.python.org/2/library/configparser.html) - (Python standard library) INI file parser.
 * [profig](http://profig.readthedocs.org/) - Config from multiple formats with value conversion.
 * [python-decouple](https://github.com/henriquebastos/python-decouple) - Strict separation of settings from code.
+* [prettyconf](https://github.com/osantana/prettyconf) - Separation of settings and code as proposed in [The Twelve-Factor App](http://12factor.net) architeture. It is highly inspired on and API compatible with: [python-decouple](https://github.com/henriquebastos/python-decouple).
 
 ## Command-line Tools
 


### PR DESCRIPTION
Prettyconf allow developers split configurations from code as described in "[The Twelve-Factor App](http://www.12factor.net)" methodology . It's API compatible and highly inspired in the project python-decouple but it implementation is more extensible and flexible than the later.