### PR TITLE
Add MagicPython - syntax highlighter for ST & Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1138,6 +1138,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * Sublime Text
     * [SublimeJEDI](https://github.com/srusskih/SublimeJEDI) - A Sublime Text plugin to the awesome auto-complete library Jedi.
     * [Anaconda](https://github.com/DamnWidget/anaconda) - Anaconda turns your Sublime Text 3 in a full featured Python development IDE.
+    * [MagicPython](https://github.com/MagicStack/MagicPython) - Supercharged syntax highlighter for Atom and Sublime Text.
 * Vim
     * [YouCompleteMe](https://github.com/Valloric/YouCompleteMe) - Includes [Jedi](https://github.com/davidhalter/jedi)-based completion engine for Python.
     * [Jedi-vim](https://github.com/davidhalter/jedi-vim) - Vim bindings for the Jedi auto-completion library for Python.


### PR DESCRIPTION
I think it's the most advanced one now. And, of course, it is awesome ;)

https://github.com/MagicStack/MagicPython

<img width="761" alt="68747470733a2f2f6d61676963737461636b2e6769746875622e696f2f4d61676963507974686f6e2f6578616d706c652e706e67" src="https://cloud.githubusercontent.com/assets/239003/10626932/d6773eac-7781-11e5-82c6-fb3bc9093dbc.png">
