### PR TITLE
Added CLAM: a high-level tool to quickly build RESTful webservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,8 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [sandman](https://github.com/jeffknupp/sandman) - Automated REST APIs for existing database-driven systems.
     * [restless](http://restless.readthedocs.org/en/latest/) - Framework agnostic REST framework based on lessons learned from Tastypie.
     * [ripozo](https://github.com/vertical-knowledge/ripozo) - Quickly creating REST/HATEOAS/Hypermedia APIs.
+ * Miscellaneous
+    * [CLAM](https://proycon.github.io/clam) - A high-level tool to quickly build RESTful webservices and web applications for command-line tools.
 
 ## Authentication
 


### PR DESCRIPTION
CLAM (https://proycon.github.io/clam) is a high-level tool to quickly build RESTful webservices and web applications for command-line tools. The tools themselves can be considered black boxes. The webservice is RESTful, the interface for human end-users is entirely produced client-side (through XSLT). Various CLAM-based services by our university are available here: http://webservices-lst.science.ru.nl/

The webservices are suited for batch processing and large data, and are typically employed in Natural Language Processing settings. CLAM is build upon flask. A tutorial video is available here: https://www.youtube.com/watch?v=GyRvaO6omEo

My work on CLAM & FoLiA was awarded the CLARIN Young Scientist Award 2015 (last week).
