### PR TITLE
Added FoLiA-Tools and PyNLPl   (NLP) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [csvkit](https://github.com/onyxfish/csvkit) - Utilities for converting to and working with CSV.
 * Archive
     * [unp](https://github.com/mitsuhiko/unp) - A command line tool that can unpack archives easily.
+* Other
+    * [FoLiA-tools](https://proycon.github.io/folia) - Tools and libraries for FoLiA: Format for Linguistic Annotation.
 
 ## Natural Language Processing
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [jieba](https://github.com/fxsjy/jieba) - Chinese Words Segmentation Utilities.
 * [langid.py](https://github.com/saffsd/langid.py) - Stand-alone language identification system.
 * [Pattern](http://www.clips.ua.ac.be/pattern) - A web mining module for the Python.
+* [PyNLPl](https://github.com/proycon/pynlpl) - A specialized Python Natural Language Processing library.
 * [SnowNLP](https://github.com/isnowfy/snownlp) - A library for processing Chinese text.
 * [TextBlob](http://textblob.readthedocs.org/) - Providing a consistent API for diving into common NLP tasks.
 


### PR DESCRIPTION
FoLiA-tools are CLI tools and Python libraries to work with documents in the FoLiA (Format for Linguistic Annotation) format. FoLiA is an XML-based file format capable of storing a wide variety of linguistic annotation types, see https://proycon.github.io/folia . FoLiA is used in the academic Natural Language Processing community by various large corpora, mainly in The Netherlands and Flanders.

The FoLiA-tools are part of the folia github repo, the actual FoLiA library is part of PyNLPl (https://github.com/proycon/pynlpl), which is a mandatory dependency. I therefore combined the two in this single pull request, I hope you don't mind. However, PyNLPl contains more than just a FoLiA library. It contains various specialised modules, such as for parsing other specialized formats (Moses, GIZA++), clients for interfacing with certain NLP servers, a module for handling Corpus Query Language, and generic functionality for text processing and basic corpus statistics.

My work on FoLiA & CLAM was awarded the CLARIN Young Scientist Award 2015 (last week).
