### PR TITLE
Correction for broken link to blaze on Science and Data Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,7 +927,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [bcbio-nextgen](https://github.com/chapmanb/bcbio-nextgen) - A toolkit providing best-practice pipelines for fully automated high throughput sequencing analysis.
 * [bccb](https://github.com/chapmanb/bcbb) - Collection of useful code related to biological analysis.
 * [Biopython](http://biopython.org/wiki/Main_Page) - Biopython is a set of freely available tools for biological computation.
-* [blaze](http://blaze.pydata.org/en/latest/) - NumPy and Pandas interface to Big Data.
+* [blaze](http://blaze.readthedocs.org/en/latest/index.html) - NumPy and Pandas interface to Big Data.
 * [cclib](http://cclib.github.io/) - A library for parsing and interpreting the results of computational chemistry packages.
 * [NetworkX](https://networkx.github.io/) - A high-productivity software for complex networks.
 * [Neupy](http://neupy.com/pages/home.html) - Running and testing different Artificial Neural Networks algorithms.


### PR DESCRIPTION
The old link for blaze (http://blaze.pydata.org/en/latest/) are broken, just replace for the new (http://blaze.readthedocs.org/en/latest/index.html)