### PR TITLE
Add Clize closes #374

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [cliff](http://docs.openstack.org/developer/cliff/) - A framework for creating command-line programs with multi-level commands.
     * [Clime](http://clime.mosky.tw) – Converting any module into a multi-command CLI app without any configuration.
     * [clint](https://github.com/kennethreitz/clint) - Python Command-line Application Tools.
+    * [clize](http://clize.readthedocs.org/) - Turn functions into command-line interfaces.
     * [colorama](https://pypi.python.org/pypi/colorama) - Cross-platform colored terminal text.
     * [docopt](http://docopt.org/) - Pythonic command line arguments parser.
     * [Gooey](https://github.com/chriskiehl/Gooey) - Turn command line programs into a full GUI application with one line


### PR DESCRIPTION
Can turn a function into a command-line interface, saving code and effort
