### PR TITLE
Please add asciimatics

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 *Libraries for building command-line application.*
 
 * Command-line Application Development
+    * [asciimatics](https://github.com/peterbrittain/asciimatics) - Cross-platform, full-screen terminal package (i.e.  mouse/keyboard input and coloured, positioned text output) complete with high-level API for complex animations and special effects.
     * [cement](http://builtoncement.com/) - CLI Application Framework for Python.
     * [click](http://click.pocoo.org/) - A package for creating beautiful command line interfaces in a composable way.
     * [cliff](http://docs.openstack.org/developer/cliff/) - A framework for creating command-line programs with multi-level commands.


### PR DESCRIPTION
I believe that [asciimatics](https://github.com/peterbrittain/asciimatics) is the terminal API that Python should have always had.  It is a more human way to program curses and also provides a drop-in replacement API for non-curses environments - all of which can be `pip` installed.

In more details, it provides a single, cross-platform API for all terminals/consoles with the following features: 

* Coloured/styled text - including 256 colours (terminal support permitting)
* Cursor positioning
* Keyboard input (without blocking or echoing)
* Mouse input (terminal support permitting)
* Detecting and handling when the console resizes
* Screen scraping
* Anti-aliased ASCII line-drawing
* Image to ASCII conversion - including JPEG and GIF formats
* Many animation effects - e.g. sprites, particle systems, banners, etc.

It has been proven to work on Windows, Linux and OSX and supports Python versions 2 and 3.  

For an idea of the sorts of things it can do, see the [gallery](https://github.com/peterbrittain/asciimatics/wiki).

It wasn't obvious to me whether this should be in the command-line tools or GUI section given that it straddles both.  I'd happily be guided by your views if you feel it is worth taking.