### PR TITLE
Added rc, Redis cache cluster system

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [HermesCache](https://pypi.python.org/pypi/HermesCache) - Python caching library with tag-based invalidation and dogpile effect prevention.
 * [johnny-cache](https://github.com/jmoiron/johnny-cache) - A caching framework for django applications.
 * [pylibmc](https://github.com/lericson/pylibmc) - A Python wrapper around the [libmemcached](http://libmemcached.org/libMemcached.html) interface.
+* [rc](https://github.com/fengsp/rc) - Redis cache system that can build cluster and batch fetch cache results in parallel.
 
 ## Email
 


### PR DESCRIPTION
One library that implements cache system for redis in Python.  It is for use
with web applications and Python scripts.  It comes with really handy apis
for easy drop-in use with common tasks, including caching decorators.  It
can be used to build a cache cluster which has a routing system that allows
you to automatically set cache on different servers, sharding can be really
easy now.  You can use it to batch fetch multiple cache results back, for
a cluster, it even does the job in parallel, we fetch results from all servers
concurrently, which means much higher performance.

It uses the redis server, which is a in-memory key-value data structure
server.  It does not implement any other backends like filesystem and does not
intend to do so.  Mostly we want to use a key-value server like redis, if you
have special needs, it is easy to write one cache decorator that stores
everything in memory using a dict or you can check out other libraries.
