### PR TITLE
loxun - write large XML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [untangle](https://github.com/stchris/untangle) - Converts XML documents to Python objects for easy access.
 * [xhtml2pdf](https://github.com/xhtml2pdf/xhtml2pdf) - HTML/CSS to PDF converter.
 * [xmltodict](https://github.com/martinblech/xmltodict) - Working with XML feel like you are working with JSON.
+* [loxun](https://github.com/roskakori/loxun) - Write large output in XML using unicode and namespaces.
 
 ## Web Crawling
 


### PR DESCRIPTION
> loxun is a Python module to write large output in XML using unicode and
> namespaces.
> For more information, visit http://pypi.python.org/pypi/loxun/

Awesome library to write large XML files, I test it with file larger than 1Gb and works like a charm
