### PR TITLE
Add pipgh (under Libraries for package and dependency management.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [Curdling](http://clarete.li/curdling/) - Curdling is a command line tool for managing Python packages.
 * [wheel](http://pythonwheels.com/) - The new standard of Python distribution and are intended to replace eggs.
+* [pipgh](https://github.com/ffunenga/pipgh) - A command-line tool to search and install packages from Github.
 
 ## Package Repositories
 


### PR DESCRIPTION
Placed at the end of the list to respect any sorting method that might be in place. Probably better placed near the `pip` entry.
