### PR TITLE
Postgres.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
     * [oursql](https://pythonhosted.org/oursql/) - A better MySQL connector with support for native prepared statements and BLOBs.
     * [PyMySQL](https://github.com/PyMySQL/PyMySQL) - Pure Python MySQL driver compatible to mysql-python.
 * PostgreSQL
+    * [Postgres.py](http://postgres-py.readthedocs.org/) - A PostgreSQL client library for humans.
     * [psycopg2](http://initd.org/psycopg/) - The most popular PostgreSQL adapter for Python.
     * [queries](https://github.com/gmr/queries) - A wrapper of the psycopg2 library for interacting with PostgreSQL.
     * [txpostgres](http://txpostgres.readthedocs.org/en/latest/) - Twisted based asynchronous driver for PostgreSQL.


### PR DESCRIPTION
Postgres.py is awesome because it's well-designed, well-tested, well-documented, portable between Python 2 and 3, and proven in production on Gratipay. Write SQL and map the return types to Python objects!
