### PR TITLE
Add try - It's never been easier to try a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.
     * [SAWS](https://github.com/donnemartin/saws) - A Supercharged AWS CLI.
     * [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
+    * [try](https://github.com/timofurrer/try) - A dead simple CLI to try out python packages - It's never been easier.
     * [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.
     * [pgcli](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting.
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

[`try`](https://github.com/timofurrer/try) makes it very easy to try out python packages.
It will automatically create a virtual environment and launch a python interpreter with the already imported package. It supports PyPI and GitHub including pulling different versions of the package into different python version environments.
In addition to that there is the option to fire up an editor instead of an interpreter.

... It's never been easier to try out python packages!

## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.

