### PR TITLE
Add diff-so-fancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [caniusepython3](https://github.com/brettcannon/caniusepython3) - Determine what projects are blocking you from porting to Python 3.
     * [cookiecutter](https://github.com/audreyr/cookiecutter) - A command-line utility that creates projects from cookiecutters (project templates).
     * [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
+    * [diff-so-fancy](https://github.com/so-fancy/diff-so-fancy) - Good looking git diffs.
     * [howdoi](https://github.com/gleitz/howdoi) - Instant coding answers via the command line.
     * [httpie](https://github.com/jkbrzt/httpie) - A command line HTTP client, a user-friendly cURL replacement.
     * [PathPicker](https://github.com/facebook/PathPicker) - Select files out of bash output.


### PR DESCRIPTION
Simply put, diff-so-fancy makes your git diffs beautiful and easy on eyes.  

![](https://cloud.githubusercontent.com/assets/39191/13622719/7cc7c54c-e555-11e5-86c4-7045d91af041.png)
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
