### PR TITLE
Adding two weekly podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1198,6 +1198,8 @@ Where to discover new Python libraries.
 * [Import Python Newsletter](http://importpython.com/newsletter/)
 * [Pycoder's Weekly](http://pycoders.com/)
 * [Python Weekly](http://www.pythonweekly.com/)
+* [Podcast.\_\_init\_\_](http://podcastinit.com/) - Podcast
+* [Talk Python To Me](https://talkpython.fm/) - Podcast
 
 ## Twitter
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

They comply with the Resources section aim: _where to discover new Python libraries_. The two podcasts have a high quality and have a complete year of sustained weekly episodes.

## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
