### PR TITLE
Jinja2 repo reallocated to Pallets project

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries and tools for templating and lexing.*
 
-* [Jinja2](https://github.com/mitsuhiko/jinja2) - A modern and designer friendly templating language.
+* [Jinja2](https://github.com/pallets/jinja) - A modern and designer friendly templating language.
 * [Chameleon](https://chameleon.readthedocs.org/en/latest/) - An HTML/XML template engine. Modeled after ZPT, optimized for speed.
 * [Genshi](https://genshi.edgewall.org/) - Python templating toolkit for generation of web-aware output.
 * [Mako](http://www.makotemplates.org/) - Hyperfast and lightweight templating for the Python platform.


### PR DESCRIPTION
Yesterday Armin Ronacher aka mitsuhiko announced the creation of Pallets project: "a Github organization which will be the home of Flask and all the associated projects". 

## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.

