### PR TITLE
Add tflearn

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,6 +995,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [pydeep](https://github.com/andersbll/deeppy)-Deep learning in python
 * [vowpal_porpoise](https://github.com/josephreisinger/vowpal_porpoise) - A lightweight Python wrapper for [Vowpal Wabbit](https://github.com/JohnLangford/vowpal_wabbit/).
 * [skflow](https://github.com/tensorflow/skflow) - A simplified interface for [TensorFlow](https://github.com/tensorflow/tensorflow) (mimicking scikit-learn).
+* [tflearn](https://github.com/tflearn/tflearn) - Deep learning library featuring a higher-level API for TensorFlow.
 
 ## MapReduce
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

Deep learning library featuring a higher-level API for TensorFlow. http://tflearn.org.
I think **tflearn** was on the homepage of HackerNews, recently.
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
