### PR TITLE
Add kaptan (configuration manager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [config](https://www.red-dove.com/config-doc/) - Hierarchical config from the author of [logging](https://docs.python.org/2/library/logging.html).
 * [ConfigObj](http://www.voidspace.org.uk/python/configobj.html) - INI file parser with validation.
 * [ConfigParser](https://docs.python.org/2/library/configparser.html) - (Python standard library) INI file parser.
+* [kaptan](https://github.com/emre/kaptan) - all-in-one configuration manager for INI, JSON, YAML, and python dicts+objects.
 * [profig](http://profig.readthedocs.org/en/default/) - Config from multiple formats with value conversion.
 * [python-decouple](https://github.com/henriquebastos/python-decouple) - Strict separation of settings from code.
 


### PR DESCRIPTION
## Why this library is awesome?
- Works with JSON, YAML, INI, python dicts and python objects
- Permissively licensed (BSD)
- Its relatively mature (turning 3 years old in May 2016)
- Packaged on [FreeBSD](http://portsmon.freebsd.org/portoverview.py?category=devel&portname=py-kaptan) and [ArchLinux](https://aur.archlinux.org/packages/python-kaptan/)
- Well-documented [with many examples](https://github.com/emre/kaptan/blob/master/README.rst)
- Used as a dependency in production software [tmuxp](https://github.com/tony/tmuxp)
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
