### PR TITLE
Add tmuxp - tmux session manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.
     * [SAWS](https://github.com/donnemartin/saws) - A Supercharged AWS CLI.
     * [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
-    * [libtmuxp](https://libtmux.git-pull.com) - Python API for controlling [tmux](https://tmux.github.io).
+    * [libtmuxp](https://libtmux.git-pull.com) - API for controlling [tmux](https://tmux.github.io).
     * [tmuxp](https://tmuxp.git-pull.com) - Manage tmux sessions via JSON/YAML configuration.
     * [try](https://github.com/timofurrer/try) - A dead simple CLI to try out python packages - It's never been easier.
     * [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.
     * [SAWS](https://github.com/donnemartin/saws) - A Supercharged AWS CLI.
     * [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
-    * [tmuxp](https://github.com/tony/tmuxp) - Manage tmux sessions via JSON/YAML configuration and interact with tmux servers, sessions, windows and panes via Python API.
+    * [libtmuxp](https://libtmux.git-pull.com) - Python API for controlling [tmux](https://tmux.github.io).
+    * [tmuxp](https://tmuxp.git-pull.com) - Manage tmux sessions via JSON/YAML configuration.
     * [try](https://github.com/timofurrer/try) - A dead simple CLI to try out python packages - It's never been easier.
     * [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.
     * [pgcli](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting.

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.
     * [SAWS](https://github.com/donnemartin/saws) - A Supercharged AWS CLI.
     * [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
+    * [tmuxp](https://github.com/tony/tmuxp) - Manage tmux sessions via JSON/YAML configuration and interact with tmux servers, sessions, windows and panes via Python API.
     * [try](https://github.com/timofurrer/try) - A dead simple CLI to try out python packages - It's never been easier.
     * [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.
     * [pgcli](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting.


### PR DESCRIPTION
## Why this software + library is awesome?

![68747470733a2f2f7261772e6769746875622e636f6d2f746f6e792f746d7578702f6d61737465722f646f632f5f7374617469632f746d7578702d64656d6f2e676966](https://cloud.githubusercontent.com/assets/26336/14935573/d52b86aa-0e9b-11e6-9682-276a11592842.gif)
- load and [tmux](https://tmux.github.io/) sessions via JSON/YAML configuration (like [teamocil](https://github.com/remiprev/teamocil) and [tmuxinator](https://github.com/tmuxinator/tmuxinator))
- manage tmux servers, sessions, windows and panes live via [Python API](https://tmuxp.readthedocs.io/en/latest/api.html) (see [quickstart](https://tmuxp.readthedocs.io/en/latest/quickstart_python.html))
- lots of [examples](https://tmuxp.readthedocs.io/en/latest/examples.html)
- Extensive [documentation](https://tmuxp.readthedocs.io/en/latest/index.html)
- Compatible with Python 2.6+, 3.3+
- Supports tmux 1.8, 1.9a, 2.0, 2.1
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
