### PR TITLE
Add vcspull - mass clone/update projects from vcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [try](https://github.com/timofurrer/try) - A dead simple CLI to try out python packages - It's never been easier.
     * [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.
     * [pgcli](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting.
+    * [vcspull](https://github.com/tony/vcspull) - Synchronize (cloning and update) projects from vcs. Supports svn, mercurial and git.
 
 ## Downloader
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

![68747470733a2f2f7261772e6769746875622e636f6d2f746f6e792f76637370756c6c2f6d61737465722f646f632f5f7374617469632f76637370756c6c2d64656d6f2e676966](https://cloud.githubusercontent.com/assets/26336/14935567/c33bd274-0e9b-11e6-8565-b3f8aabb5c84.gif)
- Supports synchronizing git, svn and mercurial repositories
- Makes it easy to restore project layouts on newly formatted systems
- Makes it easy to see updates to your favorite open source projects. Type `vcspull` in the morning to grab all the latest code
- Supports adding git remotes (upstream repo + your fork)
- Declaratively set your projects via JSON or YAML configuration ([Example configurations](https://vcspull.readthedocs.io/en/latest/examples.html))
- Supports Python 2.7, 3.3+
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
