### PR TITLE
Added aeries, a grade book viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [sanitize](https://github.com/Alir3z4/python-sanitize) - Bringing sanity to world of messed-up data.
 * [sumy](https://github.com/miso-belica/sumy) - A module for automatic summarization of text documents and HTML pages.
 * [textract](https://github.com/deanmalmgren/textract) - Extract text from any document, Word, PowerPoint, PDFs, etc.
+* [aeries](https://github.com/shreydesai/aeries) - Parses grade book data from the Aeries Student Information System.
 
 ## Forms
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

`aeries` allows you to view your grades directly from your desktop with this application without having to log onto the Aeries website and navigate the confusing portal. Note: This only works for students whose schools use the Aeries Student Information System by Eagle Software.

<img src="http://i.imgur.com/crRFbSQ.png">
<img src="http://i.imgur.com/FXQIZJ9.png">
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
