### PR TITLE
Add NSenter to DevOps Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1051,6 +1051,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Fabric](http://www.fabfile.org/) - A simple, Pythonic tool for remote execution and deployment.
 * [Fabtools](https://github.com/ronnix/fabtools) - Tools for writing awesome Fabric files.
 * [honcho](https://github.com/nickstenning/honcho) - A Python clone of [Foreman](https://github.com/ddollar/foreman), for managing Procfile-based applications.
+* [Nsenter](https://github.com/zalando/python-nsenter) - Enter Linux kernel namespaces with a single, simple "setns" syscall.
 * [pexpect](https://github.com/pexpect/pexpect) - Controlling interactive programs in a pseudo-terminal like GNU expect.
 * [psutil](https://github.com/giampaolo/psutil) - A cross-platform process and system utilities module.
 * [supervisor](https://github.com/Supervisor/supervisor) - Supervisor process control system for UNIX.


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

Added NSenter under DevOps tools. It's awesome because it is free/open-source, makes entering Linux kernel namespaces simple and is open to contributions.
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
