### PR TITLE
Add python-inquirer to command-line tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [cliff](http://docs.openstack.org/developer/cliff/) - A framework for creating command-line programs with multi-level commands.
     * [clint](https://github.com/kennethreitz/clint) - Python Command-line Application Tools.
     * [colorama](https://pypi.python.org/pypi/colorama) - Cross-platform colored terminal text.
+    * [python-inquirer](https://github.com/magmax/python-inquirer) - A collection of common interactive command line user interfaces, based on Inquirer.js
     * [docopt](http://docopt.org/) - Pythonic command line arguments parser.
     * [Gooey](https://github.com/chriskiehl/Gooey) - Turn command line programs into a full GUI application with one line
     * [python-prompt-toolkit](https://github.com/jonathanslenders/python-prompt-toolkit) - A Library for building powerful interactive command lines.


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

With this library you can make an cli-application with interactive command line user interfaces like in [Yeoman](http://yeoman.io/)
For example:
![alt text](https://raw.githubusercontent.com/lk-geimfari/kolkrabba/master/screenshots/initer-interactive.png)
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
