### PR TITLE
Add MicroPython to "Hardware" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,6 +1123,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [scapy](https://github.com/secdev/scapy) - A brilliant packet manipulation library.
 * [wifi](https://github.com/rockymeza/wifi) - A Python library and command line tool for working with WiFi on Linux.
 * [Pingo](http://www.pingo.io/) - Pingo provides a uniform API to program devices like the Raspberry Pi, pcDuino, Intel Galileo, etc.
+* [MicroPython](https://github.com/micropython/micropython) - MicroPython is a small Python3 (subset) implementation for embedded devices and constrained systems.
 
 ## Compatibility
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

MicroPython is a very small (ten times smaller) implementation of a large subset of Python3 language, which works everywhere from modest microcontroller systems (16K RAM, 128K ROM) to normal desktop systems (where it still offers benefits of a smaller size, faster startup time, better self-containment).
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.

TODO: There actually should be a separate section "Alternative
Implementations" for things like PyPy, Stackless Python, MicroPython,
etc.
