### PR TITLE
Add pbr

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [pip](https://pip.pypa.io/en/stable/) - The Python package and dependency manager.
     * [Python Package Index](https://pypi.python.org/pypi)
 * [pip-tools](https://github.com/nvie/pip-tools) - A set of tools to keep your pinned Python dependencies fresh.
+* [pbr](https://github.com/openstack-dev/pbr) - Python Build Reasonableness. OpenStack project that injects some useful and sensible default behaviors into your setuptools run.
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [Curdling](http://clarete.li/curdling/) - Curdling is a command line tool for managing Python packages.
 * [wheel](http://pythonwheels.com/) - The new standard of Python distribution and are intended to replace eggs.


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

An OpenStack project that injects some useful and sensible default behaviors into your setuptools run.

The name (_Python Build Reasonableness_) describes it well. It makes your setuptools config declarative, manages versioning via git tags, generates AUTHORS and CHANGELOG files from git log, picks up requirements.txt as dependencies, [etc](http://docs.openstack.org/developer/pbr/#what-it-does).
Very useful as a one-stop solution to packaging-related things; an alternative to combining multiple other projects (such as `setuptools_scm` + sh scripts interfacing with git + ...).
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
