### PR TITLE
add uvloop the fast implementation of asyncio event loop on top of libuv.

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [eventlet](http://eventlet.net/) - Asynchronous framework with WSGI support.
 * [gevent](http://www.gevent.org/) - A coroutine-based Python networking library that uses [greenlet](https://github.com/python-greenlet/greenlet).
 * [Tomorrow](https://github.com/madisonmay/Tomorrow) - Magic decorator syntax for asynchronous code.
+* [uvloop](https://github.com/MagicStack/uvloop) - Ultra fast implementation of asyncio event loop on top of libuv.
 
 ## Networking
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

Ultra is fast implementation of asyncio event loop on top of libuv.

http://magic.io/blog/uvloop-blazing-fast-python-networking/

## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.

Ultra fast implementation of asyncio event loop on top of libuv.