### PR TITLE
RethinkDB driver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [pycassa](https://github.com/pycassa/pycassa) - Python Thrift driver for Cassandra.
     * [PyMongo](https://docs.mongodb.org/ecosystem/drivers/python/) - The official Python client for MongoDB.
     * [redis-py](https://github.com/andymccurdy/redis-py) - The Redis Python Client.
+    * [rethinkdb](https://www.rethinkdb.com/docs/install-drivers/python/) - The Official driver for RethinkDB.
     * [telephus](https://github.com/driftx/Telephus) - Twisted based client for Cassandra.
     * [txRedis](https://github.com/deldotdr/txRedis) - Twisted based client for Redis.
 
@@ -1230,7 +1231,7 @@ Where to discover new Python libraries.
 * [@pypi](https://twitter.com/pypi)
 * [@pythontrending](https://twitter.com/pythontrending)
 * [@PythonWeekly](https://twitter.com/PythonWeekly)
- 
+
 ## Podcasts
 
 * [Podcast.init](http://podcastinit.com/)

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [pycassa](https://github.com/pycassa/pycassa) - Python Thrift driver for Cassandra.
     * [PyMongo](https://docs.mongodb.org/ecosystem/drivers/python/) - The official Python client for MongoDB.
     * [redis-py](https://github.com/andymccurdy/redis-py) - The Redis Python Client.
-    * [rethinkdb](https://www.rethinkdb.com/docs/install-drivers/python/) - The Official driver for RethinkDB.
+    * [rethinkdb](https://www.rethinkdb.com/docs/install-drivers/python/) - The official driver for RethinkDB.
     * [telephus](https://github.com/driftx/Telephus) - Twisted based client for Cassandra.
     * [txRedis](https://github.com/deldotdr/txRedis) - Twisted based client for Redis.
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

RethinkDB is the first open-source, scalable JSON database built from the ground up for the realtime web. It inverts the traditional database architecture by exposing an exciting new access model – instead of polling for changes, the developer can tell RethinkDB to continuously push updated query results to applications in realtime. RethinkDB’s realtime push architecture dramatically reduces the time and effort necessary to build scalable realtime apps.

I don't see any reason why this shouldn't be on the list.
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
