### PR TITLE
Replace broken Cool github projects link with subreddit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,7 +1203,7 @@ Where to discover new Python libraries.
 ## Websites
 
 * [r/Python](https://www.reddit.com/r/python)
-* [CoolGithubProjects](https://www.coolgithubprojects.com/)
+* [/r/CoolGithubProjects](https://www.reddit.com/r/coolgithubprojects/)
 * [Django Packages](https://www.djangopackages.com/)
 * [Full Stack Python](https://www.fullstackpython.com/)
 * [Python 3 Wall of Superpowers](http://python3wos.appspot.com/)


### PR DESCRIPTION
This PR replaces the https://coolgithubprojects.com website (which doesn't appear to exist anymore) with a fairly active subreddit that isn't just a mirror of the trending page.
It also has language specific views of projects that people submit; so if you are only interested in python projects you can easily filter projects in other languages out.