### PR TITLE
Add django-db-mailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [modoboa](https://github.com/tonioo/modoboa) - A mail hosting and management platform including a modern and simplified Web UI.
 * [Nylas Sync Engine](https://github.com/nylas/sync-engine) - Providing a RESTful API on top of a powerful email sync platform.
 * [yagmail](https://github.com/kootenpv/yagmail) - Yet another Gmail/SMTP client.
+* [django-db-mailer](https://github.com/LPgenerator/django-db-mailer) - Django module to easily send emails/sms/tts/push using django templates stored on database and managed through the Django Admin.
 
 ## Internationalization
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

Django module to easily send emails/push/sms/tts using django templates stored on database.
From box you can use it with django-celery for send background messages.
Also you have opportunity to create reports from logs by mail categories and slug.
Groups with Recipients and send by model signal also available by default.
Can be used without any depends from programming language as a external service.
That app very simple to install and use on your projects.
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
