### PR TITLE
Adding NAPALM

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [diesel](https://github.com/dieseldev/diesel) - Greenlet-based event I/O Framework for Python.
 * [pyzmq](http://zeromq.github.io/pyzmq/) - A Python wrapper for the ZeroMQ message library.
 * [txZMQ](https://github.com/smira/txZMQ) - Twisted based wrapper for the ZeroMQ message library.
+* [NAPALM](https://github.com/napalm-automation/napalm) - Cross-vendor API to manipulate network devices.
 
 ## WebSocket
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

NAPALM (Network Automation and Programmability Abstraction Layer with Multivendor support) is a Python library that implements a set of functions to interact with different router vendor devices using a unified API. 

More at: https://github.com/napalm-automation/napalm
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.
