### PR TITLE
Add Pendulum to Date and Time libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for working with dates and times.*
 
+* [Pendulum](https://github.com/sdispater/pendulum) - Python datetimes made easy.
 * [arrow](https://github.com/crsmithdev/arrow) - Better dates & times for Python.
 * [Chronyk](https://github.com/KoffeinFlummi/Chronyk) - A Python 3 library for parsing human-written times and dates.
 * [dateutil](https://github.com/dateutil/dateutil) - Extensions to the standard Python [datetime](https://docs.python.org/2/library/datetime.html) module.
@@ -184,7 +185,6 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [PyTime](https://github.com/shinux/PyTime) - A easy-use Python module which aims to operate date/time/datetime by string.
 * [pytz](https://launchpad.net/pytz) - World timezone definitions, modern and historical. Brings the [tz database](https://en.wikipedia.org/wiki/Tz_database) into Python.
 * [when.py](https://github.com/dirn/When.py) - Providing user-friendly functions to help perform common date and time actions.
-* [Pendulum](https://github.com/sdispater/pendulum) - Python datetimes made easy.
 
 ## Text Processing
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [PyTime](https://github.com/shinux/PyTime) - A easy-use Python module which aims to operate date/time/datetime by string.
 * [pytz](https://launchpad.net/pytz) - World timezone definitions, modern and historical. Brings the [tz database](https://en.wikipedia.org/wiki/Tz_database) into Python.
 * [when.py](https://github.com/dirn/When.py) - Providing user-friendly functions to help perform common date and time actions.
+* [Pendulum](https://github.com/sdispater/pendulum) - Python datetimes made easy.
 
 ## Text Processing
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

Pendulum aims at making Python datetimes easy. It fixes the flaw of the existing libraries (especially Arrow) while providing a more explicit API. Here are some examples:

```python
import pendulum

now = pendulum.now('Europe/Paris')

# Changing timezone
now.in_timezone('America/Toronto')

# Default support for common datetime formats
now.to_iso8601_string()

# Shifting time
now.add(days=2)
```

It improves the native `timedelta` type:

```
it = pendulum.interval(days=15)

# More properties
it.weeks
it.hours

# Handy methods
it.in_hours()
360
it.in_words(locale='en_us')
'2 weeks 1 day'
```

It brings its own `Period` class, which is a datetime-ware `timedelta`:

```python
dt1 = pendulum.now()
dt2 = dt1.add(days=3)

# A period is the difference between 2 instances
period = dt2 - dt1

period.in_weekdays()
period.in_weekend_days()

# A period is iterable
for dt in period:
    print(dt)
```

And finally, it improves timezones manipulation by handling normalization properly and shifting time around DST transition time:

```python
import pendulum

pendulum.create(2013, 3, 31, 2, 30, 0, 0, 'Europe/Paris')
# 2:30 for the 31th of March 2013 does not exist
# so pendulum will return the actual time which is 3:30+02:00
'2013-03-31T03:30:00+02:00'

in_utc = pendulum.create(2013, 3, 31, 0, 59, 59, 999999)
tz = pendulum.timezone('Europe/Paris')
in_paris = tz.convert(in_utc)
'2013-03-31T01:59:59.999999+01:00'

# Shifting time
in_paris = in_paris.add(microseconds=1)
'2013-03-31T03:00:00+02:00'
in_paris.subtract(microseconds=1)
'2013-03-31T01:59:59.999999+01:00'
```

For the rest you can check out the official documentation: https://pendulum.eustace.io/docs/

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.

