### PR TITLE
Adding NetAddr and Pyodbc

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [apsw](http://rogerbinns.github.io/apsw/) - Another Python SQLite wrapper.
     * [dataset](https://github.com/pudo/dataset) - Store Python dicts in a database - works with SQLite, MySQL, and PostgreSQL.
     * [pymssql](http://www.pymssql.org/en/latest/) - A simple database interface to Microsoft SQL Server.
+    * [pyodbc](https://github.com/mkleehammer/pyodbc) - An open source Python module that simplifies database connections via ODBC.
 * NoSQL Databases
     * [cassandra-python-driver](https://github.com/datastax/python-driver) - Python driver for Cassandra.
     * [HappyBase](https://github.com/wbolster/happybase) - A developer-friendly library for Apache HBase.
@@ -783,6 +784,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [diesel](https://github.com/dieseldev/diesel) - Greenlet-based event I/O Framework for Python.
 * [pyzmq](http://zeromq.github.io/pyzmq/) - A Python wrapper for the ZeroMQ message library.
 * [txZMQ](https://github.com/smira/txZMQ) - Twisted based wrapper for the ZeroMQ message library.
+* [netaddr](https://github.com/drkjam/netaddr) - A network address manipulation library.
 
 ## WebSocket
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [apsw](http://rogerbinns.github.io/apsw/) - Another Python SQLite wrapper.
     * [dataset](https://github.com/pudo/dataset) - Store Python dicts in a database - works with SQLite, MySQL, and PostgreSQL.
     * [pymssql](http://www.pymssql.org/en/latest/) - A simple database interface to Microsoft SQL Server.
-    * [pyodbc](https://github.com/mkleehammer/pyodbc) - An open source Python module that simplifies database connections via ODBC.
+    * [pyodbc](https://github.com/mkleehammer/pyodbc) - An open source module that simplifies database connections via ODBC.
 * NoSQL Databases
     * [cassandra-python-driver](https://github.com/datastax/python-driver) - Python driver for Cassandra.
     * [HappyBase](https://github.com/wbolster/happybase) - A developer-friendly library for Apache HBase.


### PR DESCRIPTION
## What is this Python project?

netaddr

```
This is a really handy module that I have used several times over the past few years. It simplifies
ipv4/ipv6 address manipulation in addition to other things like subnet calculations etc.
```

pyodbc

```
This is a very handy module that simplifies a variety of database connections/interactions
 over ODBC.  It implements the PEP 249 Python Database API Specification.
```
## What's the difference between this Python project and similar ones?

Enumerate comparisons.

netaddr

```
Right now there isn't any library listed that simplify IP address manipulation.  I've used this library
to determine if the http requests have come from Gmail proxy servers when adding linked images
in email messages (HTML).
```

pyodbc

```
Many of the database modules are specific to a certain technology.  Pyodbc works with a variety
of database technologies via different ODBC drivers.  I have used it for SQL Server, and MySQL in
the past.
```
## 

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
