### PR TITLE
xhtml2pdf is officially deprecated in favor of WeasyPrint

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [MarkupSafe](https://github.com/pallets/markupsafe) - Implements a XML/HTML/XHTML Markup safe string for Python.
 * [pyquery](https://github.com/gawel/pyquery) - A jQuery-like library for parsing HTML.
 * [untangle](https://github.com/stchris/untangle) - Converts XML documents to Python objects for easy access.
-* [xhtml2pdf](https://github.com/xhtml2pdf/xhtml2pdf) - HTML/CSS to PDF converter.
+* [WeasyPrint](http://weasyprint.org) - A visual rendering engine for HTML and CSS that can export to PDF.
 * [xmldataset](https://xmldataset.readthedocs.io) - Simple XML Parsing.
 * [xmltodict](https://github.com/martinblech/xmltodict) - Working with XML feel like you are working with JSON.
 


### PR DESCRIPTION
## What is this Python project?

WeasyPrint is a visual rendering engine for HTML and CSS that can export to PDF. It aims to support web standards for printing.

## What's the difference between this Python project and similar ones?

```xhtml2pdf``` is now deprecated. I made this PR to keep things up-to-date.
This PR is a result of conversation appeared in #680.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.

