### PR TITLE
Data science and machine learning related additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [wxPython](http://wxpython.org/) - A blending of the wxWidgets C++ class library with the Python.
 * [PyGObject](https://wiki.gnome.org/Projects/PyGObject) - Python Bindings for GLib/GObject/GIO/GTK+ (GTK+3)
 * [Flexx](https://github.com/zoofIO/flexx) - Flexx is a pure Python toolkit for creating GUI's, that uses web technology for its rendering.
+* [Rapyd-Tk](http://www.bitflipper.ca/rapyd/) - Tk GUI builder tool
 
 ## Game Development
 

--- a/README.md
+++ b/README.md
@@ -1007,6 +1007,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [pydeep](https://github.com/andersbll/deeppy) - Deep learning in python
 * [vowpal_porpoise](https://github.com/josephreisinger/vowpal_porpoise) - A lightweight Python wrapper for [Vowpal Wabbit](https://github.com/JohnLangford/vowpal_wabbit/).
 * [skflow](https://github.com/tensorflow/skflow) - A simplified interface for [TensorFlow](https://github.com/tensorflow/tensorflow) (mimicking scikit-learn).
+* [Keras](https://github.com/tensorflow/skflow) - A deep learning library built on top of [Theano](https://github.com/Theano/Theano) and [TensorFlow](https://github.com/tensorflow/tensorflow) 
 
 ## MapReduce
 

--- a/README.md
+++ b/README.md
@@ -978,6 +978,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [pygal](http://www.pygal.org/en/latest/) - A Python SVG Charts Creator.
 * [pygraphviz](https://pypi.python.org/pypi/pygraphviz) - Python interface to [Graphviz](http://www.graphviz.org/).
 * [PyQtGraph](http://www.pyqtgraph.org/) - Interactive and realtime 2D/3D/Image plotting and science/engineering widgets.
+* [Seaborn](https://stanford.edu/~mwaskom/software/seaborn/) - Statistical data visualization from Stanford
 * [SnakeViz](http://jiffyclub.github.io/snakeviz/) - A browser based graphical viewer for the output of Python's cProfile module.
 * [vincent](https://github.com/wrobstory/vincent) - A Python to Vega translator.
 * [VisPy](http://vispy.org/) - High-performance scientific visualization based on OpenGL.
@@ -993,6 +994,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for Machine Learning. See: [awesome-machine-learning](https://github.com/josephmisiti/awesome-machine-learning#python).*
 
+* [brew] (https://pypi.python.org/pypi/brew/0.1.3) - Ensemble learning methods
 * [Crab](https://github.com/muricoca/crab) - A ﬂexible, fast recommender engine.
 * [gensim](https://github.com/piskvorky/gensim) - Topic Modelling for Humans.
 * [hebel](https://github.com/hannes-brt/hebel) - GPU-Accelerated Deep Learning Library in Python.

--- a/README.md
+++ b/README.md
@@ -948,6 +948,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [astropy](http://www.astropy.org/) - A community Python library for Astronomy.
 * [bcbio-nextgen](https://github.com/chapmanb/bcbio-nextgen) - A toolkit providing best-practice pipelines for fully automated high throughput sequencing analysis.
 * [bccb](https://github.com/chapmanb/bcbb) - Collection of useful code related to biological analysis.
+* [bcolz](https://github.com/Blosc/bcolz) - A columnar data container for big datasets that can be compressed
 * [Biopython](http://biopython.org/wiki/Main_Page) - Biopython is a set of freely available tools for biological computation.
 * [blaze](https://github.com/blaze/blaze) - NumPy and Pandas interface to Big Data.
 * [cclib](http://cclib.github.io/) - A library for parsing and interpreting the results of computational chemistry packages.
@@ -960,6 +961,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Open Mining](https://github.com/mining/mining) - Business Intelligence (BI) in Python (Pandas web interface)
 * [orange](http://orange.biolab.si/) - Data mining, data visualization, analysis and machine learning through visual programming or Python scripting.
 * [Pandas](http://pandas.pydata.org/) - A library providing high-performance, easy-to-use data structures and data analysis tools.
+* [Paratext](https://github.com/wiseio/paratext) - a library for reading text files over multiple cores.
 * [PyDy](http://www.pydy.org/) - Short for Python Dynamics, used to assist with workflow in the modeling of dynamic motion based around NumPy, SciPy, IPython, and matplotlib.
 * [PyMC](https://github.com/pymc-devs/pymc3) - Markov Chain Monte Carlo sampling toolkit.
 * [RDKit](http://www.rdkit.org/) - Cheminformatics and Machine Learning Software.
@@ -983,6 +985,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [SnakeViz](http://jiffyclub.github.io/snakeviz/) - A browser based graphical viewer for the output of Python's cProfile module.
 * [vincent](https://github.com/wrobstory/vincent) - A Python to Vega translator.
 * [VisPy](http://vispy.org/) - High-performance scientific visualization based on OpenGL.
+* [caravel](https://github.com/airbnb/caravel) - data exploration platform in Python
 
 ## Computer Vision
 
@@ -1009,6 +1012,10 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [vowpal_porpoise](https://github.com/josephreisinger/vowpal_porpoise) - A lightweight Python wrapper for [Vowpal Wabbit](https://github.com/JohnLangford/vowpal_wabbit/).
 * [skflow](https://github.com/tensorflow/skflow) - A simplified interface for [TensorFlow](https://github.com/tensorflow/tensorflow) (mimicking scikit-learn).
 * [Keras](https://github.com/tensorflow/skflow) - A deep learning library built on top of [Theano](https://github.com/Theano/Theano) and [TensorFlow](https://github.com/tensorflow/tensorflow) 
+* [FukuML](https://pypi.python.org/pypi/FukuML/0.3.0) A simple machine learning library
+* [Jubakit](http://jubat.us/en/jubakit/index.html) Python bindings for [Jubatus](http://jubat.us/en/index.html), a distributed online machine learning framework
+* [XGBoost](https://github.com/dmlc/xgboost), implementation of scalable, portable and distributed gradient boosting algorithm
+* [PyGMO](http://pagmo.sourceforge.net/pygmo/documentation/algorithms.html), evolutonary computing for Python
 
 ## MapReduce
 

--- a/README.md
+++ b/README.md
@@ -534,6 +534,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for serializing complex data types*
 
 * [marshmallow](https://github.com/marshmallow-code/marshmallow) - marshmallow is an ORM/ODM/framework-agnostic library for converting complex datatypes, such as objects, to and from native Python datatypes.
+* [cloudpickle](https://github.com/cloudpipe/cloudpickle) - Extended pickling support for Python objects
+* [tblib](https://pypi.org/project/tblib/) - Traceback serialization library
 
 ## Authentication
 
@@ -771,6 +773,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [eventlet](http://eventlet.net/) - Asynchronous framework with WSGI support.
 * [gevent](http://www.gevent.org/) - A coroutine-based Python networking library that uses [greenlet](https://github.com/python-greenlet/greenlet).
 * [Tomorrow](https://github.com/madisonmay/Tomorrow) - Magic decorator syntax for asynchronous code.
+* [locket](https://github.com/mwilliamson/locket.py) - File-based locks for Python for Linux and Windows 
 
 ## Networking
 
@@ -1162,6 +1165,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [algorithms](https://github.com/nryoung/algorithms) - A module of algorithms for Python.
 * [python-patterns](https://github.com/faif/python-patterns) - A collection of design patterns in Python.
 * [sortedcontainers](http://www.grantjenks.com/docs/sortedcontainers/) - Fast, pure-Python implementation of SortedList, SortedDict, and SortedSet types.
+* [heapdict](https://pypi.org/project/HeapDict/) -  implements the MutableMapping ABC, meaning it works pretty much like a regular Python dict. It’s designed to be used as priority queue
+* [zict](https://github.com/dask/zict) - Mutable Mapping interfaces
 
 ## Editor Plugins
 


### PR DESCRIPTION
Added several interesting projects related to data analysis and machine learning, which I used or tested lately and which were missing from the list (remove them if them exist in late contributions, or move to other sections, if necessary):

Seaborn - data visualization library;
Keras - deep learning library for ANN;
RapydTk - Tk GUI builder tool. Haven't used it, but there aren't many similar tools, so I included it
bcolz - a young project but interesting for big data in-memory storage and analysis
paratext - a library for reading text files over multiple cores
caravel - AirBnB's data exploration platform written in Python
brew - ensemble learning methods in Python
FukuML-  simple machine learning library, with focus on kernel methods
jubakit - Python bindings for a Jubatus distributed online machine learning framework
XGBoost - implementation of scalable, portable and distributed gradient boosting algorithm; considering its relevance, just ask any Kaggler :)
PyGMO - evolutionary computing for Python (might be moved to scientific computing section as well)
