### PR TITLE
Added 'pagan' to Imagery

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for manipulating images.*
 
+* [pagan](https://github.com/daboth/pagan) - is avatar generator for absolute nerds.
 * [pillow](https://github.com/python-pillow/Pillow) - Pillow is the friendly [PIL](http://www.pythonware.com/products/pil/) fork.
 * [hmap](https://github.com/rossgoodwin/hmap) - Image histogram remapping.
 * [imgSeek](https://sourceforge.net/projects/imgseek/) - A project for searching a collection of images using visual similarity.


### PR DESCRIPTION
## What is this Python project?

## What's the difference between this Python project and similar ones?

Remember those good old days when your own imagination was a big part of the computer gaming experience? All the limitations of the hardware forced you to fill the void left by poorly pixelated images by yourself. Well, pagan tries to give back some of those nostalgic feelings by providing identicons in an oldschool look that are inspired from retro roleplaying adventure games.

Each string input will be hashed and generates a unique avatar image. The purpose of pagan is to use it for generating a user image in any web application. It is is meant to replace default user images when creating new accounts or to enhance comment sections, e.g. visualizing the authors ip address or username.

![](https://raw.githubusercontent.com/daboth/pagan/master/images/pagan.png)
![](https://raw.githubusercontent.com/daboth/pagan/master/images/python.png)
![](https://raw.githubusercontent.com/daboth/pagan/master/images/retro.png)

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.

