### PR TITLE
Adding sched module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,6 +1080,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [schedule](https://github.com/dbader/schedule) - Python job scheduling for humans.
 * [Spiff](https://github.com/knipknap/SpiffWorkflow) - A powerful workflow engine implemented in pure Python.
 * [TaskFlow](http://docs.openstack.org/developer/taskflow/) - A Python library that helps to make task execution easy, consistent and reliable.
+* [sched](https://docs.python.org/2/library/sched.html) - (Python standard library) A module when a general purpose event scheduler is needed.
 
 ## Foreign Function Interface
 


### PR DESCRIPTION
## What is this Python project?

sched is a module in the standard lib that implements a general purpose event scheduler.
## What's the difference between this Python project and similar ones?

I think that it would be great to let people know about an already baked in module for event or job scheduling in python before recommending 3rd party libraries. At least especially when starting out.
## 

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.

The sched module is a part of the standard library and not many people
may know about it.
