### PR TITLE
Fixed pypi url (warehouse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Local PyPI repository server and proxies.*
 
 * [warehouse](https://github.com/pypa/warehouse) - Next generation Python Package Repository (PyPI).
-    * [Warehouse](https://warehouse.python.org/)
+    * [Warehouse](https://pypi.org/)
 * [bandersnatch](https://bitbucket.org/pypa/bandersnatch) - PyPI mirroring tool provided by Python Packaging Authority (PyPA).
 * [devpi](http://doc.devpi.net/latest/) - PyPI server and packaging/testing/release tool.
 * [localshop](https://github.com/mvantellingen/localshop) - Local PyPI server (custom packages and auto-mirroring of pypi).


### PR DESCRIPTION
Just a fix for warehouse url. Now it is on own domain name: https://pypi.org

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.

