### PR TITLE
Add django-th (trigger happy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Automate actions and tasks*
 
-* [django-th](https://github.com/foxmask/django-th) - An IFTTT clone, to trigger actions bridging internet services.
+* [TriggerHappy](https://github.com/foxmask/django-th) - An IFTTT clone, to trigger actions bridging internet services, based on Django.
 
 ## Build Tools
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     - [Asset Management](#asset-management)
     - [Audio](#audio)
     - [Authentication](#authentication)
+    - [Automation](#automation)
     - [Build Tools](#build-tools)
     - [Caching](#caching)
     - [ChatOps Tools](#chatops-tools)
@@ -181,6 +182,12 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [PyJWT](https://github.com/jpadilla/pyjwt) - Implementation of the JSON Web Token draft 01.
     * [python-jws](https://github.com/brianloveswords/python-jws) - Implementation of JSON Web Signatures draft 02.
     * [python-jwt](https://github.com/davedoesdev/python-jwt) - Module for generating and verifying JSON Web Tokens.
+
+## Automation
+
+*Automate actions and tasks*
+
+* [django-th](https://github.com/foxmask/django-th) - An IFTTT clone, to trigger actions bridging internet services.
 
 ## Build Tools
 


### PR DESCRIPTION
## What is this Python project?

The goal of this project is to be independent from any other solution like IFTTT, CloudWork or others.

Thus you could host your own solution and manage your own triggers without depending on any non-free solution.

With this project you can host triggers for you.

All you need is to have a hosting provider (or simply your own server ;) ) who permits to use a manager of tasks like "cron" and, of course Python.

## What's the difference between this Python project and similar ones?

I couldn't spot a similar project.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.

