### PR TITLE
Add configure package to the Configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [config](https://www.red-dove.com/config-doc/) - Hierarchical config from the author of [logging](https://docs.python.org/2/library/logging.html).
 * [ConfigObj](http://www.voidspace.org.uk/python/configobj.html) - INI file parser with validation.
 * [ConfigParser](https://docs.python.org/2/library/configparser.html) - (Python standard library) INI file parser.
+* [configure](http://configure.readthedocs.io/en/latest/index.html) -  a thin wrapper around PyYAML which extends YAML with inheritance, composition and (so called) “object-graph configuration” features.
 * [profig](http://profig.readthedocs.org/en/default/) - Config from multiple formats with value conversion.
 * [python-decouple](https://github.com/henriquebastos/python-decouple) - Strict separation of settings from code.
 


### PR DESCRIPTION
## What is this Python project?

Configure is a thin wrapper around PyYAML which extends already readable and powerful YAML with inheritance, composition and (so called) “object-graph configuration” features.


## What's the difference between this Python project and similar ones?

1. This package works with any of YAML, JSON or a mix of both formats
2. It has inheritance, composition and object-graph refrences features
3. Flexible configuration loading. Can be load from file, dictionary or string
4. A separate method for logging configuration

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.

This package works with any of YAML, JSON or a mix of both formats