### PR TITLE
Add django-material

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Deform](https://github.com/Pylons/deform) - Python HTML form generation library influenced by the formish form generation library.
 * [django-bootstrap3](https://github.com/dyve/django-bootstrap3) - Bootstrap 3 integration with Django.
 * [django-crispy-forms](https://github.com/django-crispy-forms/django-crispy-forms) - A Django app which lets you create beautiful forms in a very elegant and DRY way.
+* [django-material](https://github.com/viewflow/django-material) - Material design for Django Forms.
 * [django-remote-forms](https://github.com/WiserTogether/django-remote-forms) - A platform independent Django form serializer.
 * [WTForms](https://github.com/wtforms/wtforms) - A flexible forms validation and rendering library.
 


### PR DESCRIPTION
## What is this Python project?

Google Material Design for Django Forms and Admin

## What's the difference between this Python project and similar ones?

1. Forms 
   - New way to render django forms
   - Strong Python/HTML code separation
   - Easy redefinition of particular fields rendering
   - Complex form layout support
2. Frontend
  - Django Admin replacement build with django class-bases-views 
3. Admin
   - Material-designed django admin


--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.

