### PR TITLE
Switch boto to boto3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,7 +1084,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for accessing third party services APIs. See: [List of Python API Wrappers and Libraries](https://github.com/realpython/list-of-python-api-wrappers).*
 
 * [apache-libcloud](https://libcloud.apache.org/) - One Python library for all clouds.
-* [boto](https://github.com/boto/boto) - Python interface to Amazon Web Services.
+* [boto3](https://github.com/boto/boto3) - Python interface to Amazon Web Services.
 * [django-wordpress](https://github.com/sunlightlabs/django-wordpress/) - WordPress models and views for Django.
 * [facebook-sdk](https://github.com/mobolic/facebook-sdk) - Facebook Platform Python SDK.
 * [facepy](https://github.com/jgorset/facepy) - Facepy makes it really easy to interact with Facebook's Graph API


### PR DESCRIPTION
Template doesn't really make sense for this change...

Boto3 is the current up to date version of boto. Despite what the name implies, it is also python 2.6 and 2.7 compatible.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
