### PR TITLE
Add ntfy

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
     * [howdoi](https://github.com/gleitz/howdoi) - Instant coding answers via the command line.
     * [httpie](https://github.com/jkbrzt/httpie) - A command line HTTP client, a user-friendly cURL replacement.
+    * [ntfy](https://github.com/dschep/ntfy) - a CLI tool to send desktop & push notifications, on demand or automatically when commands finish.
     * [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.
     * [PathPicker](https://github.com/facebook/PathPicker) - Select files out of bash output.
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.


### PR DESCRIPTION
## What is this Python project?

[`ntfy`](https://github.com/dschep/ntfy) brings desktop & push notifications to your shell. It can send notifications immediately or wrap a command and send you a notification when it's done. It can even do so automatically!

## What's the difference between this Python project and similar ones?

I don't know of any similar Python projects.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.

