### PR TITLE
Adding moto to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,6 +953,11 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [python-lambda](https://github.com/nficano/python-lambda) - A toolkit for developing and deploying Python code in AWS Lambda.
 * [Zappa](https://github.com/Miserlou/Zappa) - A tool for deploying WSGI applications on AWS Lambda and API Gateway.
 
+## Shells
+*Bash like python shells for interactive use.*
+
+* [xonsh](https://github.com/xonsh/xonsh) - Use linux shell and python IDLE in one.
+
 ## Specific Formats Processing
 
 *Libraries for parsing and manipulating specific text formats.*

--- a/README.md
+++ b/README.md
@@ -1030,6 +1030,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [sixpack](https://github.com/seatgeek/sixpack) - A language-agnostic A/B Testing framework.
     * [splinter](https://github.com/cobrateam/splinter) - Open source tool for testing web applications.
 * Mock
+    * [moto](https://github.com/spulec/moto) - A mock tool for boto.
     * [doublex](https://pypi.python.org/pypi/doublex) - Powerful test doubles framework for Python.
     * [freezegun](https://github.com/spulec/freezegun) - Travel through time by mocking the datetime module.
     * [httmock](https://github.com/patrys/httmock) - A mocking library for requests for Python 2.6+ and 3.2+.


### PR DESCRIPTION
Adding moto library as it's a great way to mock AWS boto requests.

## What is this Python project?

Mock framework for AWS boto.
Xonsh shell - linux bash like shell with python mixed in.

## What's the difference between this Python project and similar ones?
There aren't similar libraries on this list.
The other mocking tools that are on the list aren't focused on AWS.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
