### PR TITLE
Fix mutagen link to Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [id3reader](http://nedbatchelder.com/code/modules/id3reader.py) - A Python module for reading MP3 meta data.
 * [m3u8](https://github.com/globocom/m3u8) - A module for parsing m3u8 file.
 * [mingus](http://bspaans.github.io/python-mingus/) - An advanced music theory and notation package with MIDI file and playback support.
-* [mutagen](https://bitbucket.org/lazka/mutagen) - A Python module to handle audio metadata.
+* [mutagen](https://github.com/quodlibet/mutagen) - A Python module to handle audio metadata.
 * [pydub](https://github.com/jiaaro/pydub) - Manipulate audio with a simple and easy high level interface.
 * [pyechonest](https://github.com/echonest/pyechonest) - Python client for the [Echo Nest](http://developer.echonest.com/) API.
 * [talkbox](http://scikits.appspot.com/talkbox) - A Python library for speech/signal processing.


### PR DESCRIPTION
mutagen moved from Bitbucket (https://bitbucket.org/lazka/mutagen) to Github (https://github.com/quodlibet/mutagen)