### PR TITLE
Remove pycrypto (vinta/awesome-python#819)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,6 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [hashids](https://github.com/davidaurelio/hashids-python) - Implementation of [hashids](http://hashids.org) in Python.
 * [Paramiko](http://www.paramiko.org/) - A Python (2.6+, 3.3+) implementation of the SSHv2 protocol, providing both client and server functionality.
 * [Passlib](https://pythonhosted.org/passlib/) - Secure password storage/hashing library, very high level.
-* [PyCrypto](https://www.dlitz.net/software/pycrypto/) - The Python Cryptography Toolkit.
 * [PyNacl](https://github.com/pyca/pynacl) - Python binding to the Networking and Cryptography (NaCl) library.
 
 ## Data Analysis


### PR DESCRIPTION
It appears pycrypto is no longer maintained and has known vulnerabilities, see:
dlitz/pycrypto#176
dlitz/pycrypto#173

Appears that larger projects (paramiko, ansible, twisted) have moved over to PyCA's cryptography, which is already on the list.

## What is this Python project?

Describe features.

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
