### PR TITLE
Add Pycycle Command-Line-Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [colorama](https://pypi.python.org/pypi/colorama) - Cross-platform colored terminal text.
     * [docopt](http://docopt.org/) - Pythonic command line arguments parser.
     * [Gooey](https://github.com/chriskiehl/Gooey) - Turn command line programs into a full GUI application with one line
+    * [Pycycle](https://github.com/bndr/pycycle) - Find and fix circular (cyclic) imports in your project.
     * [python-prompt-toolkit](https://github.com/jonathanslenders/python-prompt-toolkit) - A Library for building powerful interactive command lines.
 * Productivity Tools
     * [aws-cli](https://github.com/aws/aws-cli) - A universal command-line interface for Amazon Web Services.


### PR DESCRIPTION
## What is this Python project?

Code with circular imports in python often raises an obscure Exception (ImportError: Cannot import name X) which tells nothing about the cycle.

I have come across this problem several times, and depending on the project size it becomes problematic to identify where the problem is. This tool shows you the chain of the imports that are causing the problem, after that is up to developer to fix it e.g. move the imports to the bottom, or move the imports inside some function.

## What's the difference between this Python project and similar ones?

There are none.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
