### PR TITLE
Add ieighteen for i18n, Automation of Translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [Babel](http://babel.pocoo.org/en/latest/) - An internationalization library for Python.
 * [PyICU](https://github.com/ovalhub/pyicu) - A wrapper of International Components for Unicode C++ library ([ICU](http://site.icu-project.org/)).
+* [ieighteen](https://github.com/emadehsan/ieighteen) - Automates translation of Natural Languages, using (free) Google Translate APIs.
 
 ## Job Scheduler
 


### PR DESCRIPTION
## Automate Translation of one Natural Language to another w/o paying money

Google Translation APIs are paid. Businesses usually pay for **i18n** of their Apps and Websites.
While one could write a Scrapper (probably using Selenium because of AJAX) to translate each String to targeted language. But that would tiresome. It uses a specific Google Translate API to translate, as described in Project.

Disclaimer:
I have written this.