### PR TITLE
Add python fire

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [colorama](https://pypi.python.org/pypi/colorama) - Cross-platform colored terminal text.
     * [docopt](http://docopt.org/) - Pythonic command line arguments parser.
     * [Gooey](https://github.com/chriskiehl/Gooey) - Turn command line programs into a full GUI application with one line
+    * [Python-Fire](https://github.com/google/python-fire) - A library for creating command line interfaces (CLIs) from absolutely any Python object.
     * [python-prompt-toolkit](https://github.com/jonathanslenders/python-prompt-toolkit) - A Library for building powerful interactive command lines.
 * Productivity Tools
     * [aws-cli](https://github.com/aws/aws-cli) - A universal command-line interface for Amazon Web Services.


### PR DESCRIPTION
## What is this Python project?

https://github.com/google/python-fire

- Python Fire is a simple way to create a CLI in Python.
- Python Fire is a helpful tool for developing and debugging Python code.
- Python Fire helps with exploring existing code or turning other people's code
into a CLI.
- Python Fire makes transitioning between Bash and Python easier.
- Python Fire makes using a Python REPL easier by setting up the REPL with the
modules and variables you'll need already imported and created.

## What's the difference between this Python project and similar ones?

Fire is not as flexible as [click](https://github.com/pallets/click), yet it provides an easier way to start a simple CLI program. 

--

Anyone who agrees with this pull request could vote for it by adding a 👍 to it, and usually, the maintainer will merge it when votes reach 20.