### PR TITLE
Add cachecontrol, which adds caching to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for caching data.*
 
 * [Beaker](https://github.com/bbangert/beaker) - A library for caching and sessions for use with web applications and stand-alone Python scripts and applications.
+* [CacheControl](https://github.com/ionrock/cachecontrol) - A (client-side) caching layer for use with the requests library.
 * [DiskCache](http://www.grantjenks.com/docs/diskcache/) - SQLite and file backed cache backend with faster lookups than memcached and redis.
 * [django-cache-machine](https://github.com/django-cache-machine/django-cache-machine) - Automatic caching and invalidation for Django models.
 * [django-cacheops](https://github.com/Suor/django-cacheops) - A slick ORM cache with automatic granular event-driven invalidation.


### PR DESCRIPTION
## What is this Python project?

It's a very simple to use caching layer for the requests library.

## What's the difference between this Python project and similar ones?

It's similar in scope to the betamax and VCR libraries, but those focus on (gathering data for) testing while CacheControl focuses on working like a real cache.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
