### PR TITLE
Add mist.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Fabric](http://www.fabfile.org/) - A simple, Pythonic tool for remote execution and deployment.
 * [Fabtools](https://github.com/ronnix/fabtools) - Tools for writing awesome Fabric files.
 * [honcho](https://github.com/nickstenning/honcho) - A Python clone of [Foreman](https://github.com/ddollar/foreman), for managing Procfile-based applications.
+* [Mist.io](https://github.com/mistio/mist.io) - An open platform for managing heterogeneous infrastructures
 * [OpenStack](http://www.openstack.org/) - Open source software for building private and public clouds.
 * [pexpect](https://github.com/pexpect/pexpect) - Controlling interactive programs in a pseudo-terminal like GNU expect.
 * [psutil](https://github.com/giampaolo/psutil) - A cross-platform process and system utilities module.


### PR DESCRIPTION
## What is this Python project?

Mist.io is a web application that helps you manage and monitor virtual machines across different clouds and infrastructures. Public clouds included are AWS, GCE, Azure, DigitalOcean, SoftLayer, Rackspace, Vultr. OpenStack is also supported, Docker, plus vSphere and KVM

The same functionality is offered across all infrastructures (list VMs, create new ones, tag, start/stop/reboot/destroy, associate ssh keys, access web shell, run scripts, schedule scripts). 

## What's the difference between this Python project and similar ones?

Being a web application it provides graphical management of infrastructure. Also contains an API and cmd to perform same tasks over the console
--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
