### PR TITLE
Add Module Linker

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 ## Editor Plugins and IDEs
 
+* GitHub
+    * [Module Linker](https://fiatjaf.github.io/module-linker/#/python) - Add directly links to packages `import`ed when browsing source files on GitHub.
 * Emacs
     * [Elpy](https://github.com/jorgenschaefer/elpy) - Emacs Python Development Environment.
 * Sublime Text


### PR DESCRIPTION
## What is this Python project?

[Module Linker](http://fiatjaf.alhur.es/module-linker/#/python) is a Chrome Extension that turns `import` declarations into actual `<a href="...">` links to the source code (or standard library documentation) of the package being imported. If what is being imported is a module from the same package, Module Linker links to that file.

![](https://raw.githubusercontent.com/fiatjaf/module-linker/gh-pages/screenshot/python-screencast.gif)

If for some reason you spend some time reading code and browsing source code on GitHub, this extension will make your do your job faster and more pleasantly.

---

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
