### PR TITLE
Add cx_Oracle link

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [apsw](http://rogerbinns.github.io/apsw/) - Another Python SQLite wrapper.
     * [dataset](https://github.com/pudo/dataset) - Store Python dicts in a database - works with SQLite, MySQL, and PostgreSQL.
     * [pymssql](http://www.pymssql.org/en/latest/) - A simple database interface to Microsoft SQL Server.
+    * [pyodbc](https://mkleehammer.github.io/pyodbc/) - pyodbc is an open source module for accessing ODBC databases.
 * NoSQL Databases
     * [cassandra-python-driver](https://github.com/datastax/python-driver) - Python driver for Cassandra.
     * [HappyBase](https://github.com/wbolster/happybase) - A developer-friendly library for Apache HBase.

--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [redis-py](https://github.com/andymccurdy/redis-py) - The Redis Python Client.
     * [telephus](https://github.com/driftx/Telephus) - Twisted based client for Cassandra.
     * [txRedis](https://github.com/deldotdr/txRedis) - Twisted based client for Redis.
+* Oracle Databases
+    * [cx_Oracle](https://oracle.github.io/python-cx_Oracle/) - Extension module that enables access to Oracle Databases
 
 ## Date and Time
 


### PR DESCRIPTION
Cx_Oracle is awesome because it provides easy access to Oracle 10g, 11g
and 12c databases. Cx_Oracle has been around a long time and lots of
people use it. It's a great way to start your rdbms day. :fireworks: