### PR TITLE
Add djsw-wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,6 +902,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [django-formapi](https://github.com/5monkeys/django-formapi) - Create JSON APIs with Django's form validation.
     * [django-rest-framework](http://www.django-rest-framework.org/) - A powerful and flexible toolkit to build web APIs.
     * [django-tastypie](http://tastypieapi.org/) - Creating delicious APIs for Django apps.
+    * [djsw-wrapper](https://github.com/ErintLabs/django-openapi-gen) - Create DjangoRestFramework-backed REST APIs from Swagger schema.
 * Flask
     * [eve](https://github.com/nicolaiarocci/eve) - REST API framework powered by Flask, MongoDB and good intentions.
     * [flask-api-utils](https://github.com/marselester/flask-api-utils) - Taking care of API representation and authentication for Flask.


### PR DESCRIPTION
Added djsw-wrapper

## What is this Python project?

It allows to create RESTful APIs using Django Rest Framework directly from Swagger schema

## What's the difference between this Python project and similar ones?

There are Swagger bindings for Flask and Pyramid (http://swagger.io/open-source-integrations/#python-18), but none for Django. This tool allows to use Django (DRF) to create RESTful APIs.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
