### PR TITLE
Update httplib2 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for working with HTTP.*
 
 * [grequests](https://github.com/kennethreitz/grequests) - requests + gevent for asynchronous HTTP requests.
-* [httplib2](https://github.com/jcgregorio/httplib2) - Comprehensive HTTP client library.
+* [httplib2](https://github.com/httplib2/httplib2) - Comprehensive HTTP client library.
 * [requests](http://docs.python-requests.org/en/latest/) - HTTP Requests for Humans™.
 * [treq](https://github.com/twisted/treq) - Python requests like API built on top of Twisted's HTTP client.
 * [urllib3](https://github.com/shazow/urllib3) - A HTTP library with thread-safe connection pooling, file post support, sanity friendly.


### PR DESCRIPTION
The readme of https://github.com/jcgregorio/httplib2 says that repo is deprecated, and we should be using https://github.com/httplib2/httplib2.