### PR TITLE
Add AppImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries to create packaged executables for release distribution.*
 
+* [AppImage](http://appimage.org/) - Bundles applications into stand-alone executables including the Python runtime, modules, libraries, and resources (Linux).
 * [dh-virtualenv](https://github.com/spotify/dh-virtualenv) - Build and distribute a virtualenv as a Debian package.
 * [Nuitka](http://nuitka.net/) - Compile scripts, modules, packages to an executable or extension module.
 * [py2app](http://pythonhosted.org/py2app/) - Freezes Python scripts (Mac OS X).


### PR DESCRIPTION
## What is this Python project?

 [AppImage](http://appimage.org/) - Bundles applications into stand-alone executables including the Python runtime, modules, libraries, and resources (Linux)

## What's the difference between this Python project and similar ones

Providing an [AppImage](http://appimage.org/) has, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages. For example, [Ultimaker Cura](https://ultimaker.com/en/products/cura-software) is a PyQt application distributed in AppImage format for Linux.

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
