### PR TITLE
README.md: Add fecon235 for economics under Science

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,6 +935,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [bccb](https://github.com/chapmanb/bcbb) - Collection of useful code related to biological analysis.
 * [Biopython](http://biopython.org/wiki/Main_Page) - Biopython is a set of freely available tools for biological computation.
 * [cclib](http://cclib.github.io/) - A library for parsing and interpreting the results of computational chemistry packages.
+* [fecon235](https://github.com/rsvp/fecon235) - Computational data tools for financial economics.
 * [NetworkX](https://networkx.github.io/) - A high-productivity software for complex networks.
 * [NIPY](http://nipy.org) - A collection of neuroimaging toolkits.
 * [NumPy](http://www.numpy.org/) - A fundamental package for scientific computing with Python.


### PR DESCRIPTION
## What is this Python project?

https://github.com/rsvp/fecon235  - ***Stars:*** 142 (as of 2017-04-20)

Python tools for financial economics. Code is demonstrated using Jupyter
notebooks for statistical computations and collection of raw data in
real-time.  Extensive use of numpy, scipy, pandas, matplotlib especially
for time-series analysis and econometrics, yet the user interface is
very friendly.

API to access data include sources such as: U.S. Federal Reserve Bank,
Quandl, Yahoo and Google Finance.

### Verify theoretical ideas and practical methods interactively

Here is a rendering of a Jupyter notebook for Housing economy, home prices and affordibility https://git.io/housing If you had executed that notebook locally, it would have also retrieved the latest available data and recomputed the results.

How is worker's wage correlated with GDP output? See https://git.io/gdpwage To score the Federal Reserve's performance under its dual mandate for inflation and unemployment, see https://git.io/fed (where tangentially the Phillips curve is discredited by constructing heat map scatter plots). Please see https://git.io/fedfunds to forecast the Fed Funds rate using futures contracts on LIBOR.

In https://git.io/gold we make a conjecture that real gold prices is a stationary time-series bound by real interest rates. In https://git.io/xbt we statistically analyze Bitcoin as a financial asset.

In https://git.io/equities we examine the separable components of total return for equities, especially due to enterprise earnings and market speculation, using S&P data assembled by Robert Shiller which goes back to the year 1871. In https://git.io/gdpspx we examine the close relationship between the real economy and the equities market, while demonstrating the Holt-Winters time-series model for predictions.


## What's the difference between this Python project and similar ones?

We would recommend the Quantitative Economics site by Thomas [Sargent](https://lectures.quantecon.org/py/index.html) for economists interested in theory, whereas [fecon235](https://github.com/rsvp/fecon235) has a more data science emphasis with applications to finance.  Thus the two projects are complementary.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.

Questions? Chat at https://gitter.im/rsvp/fecon235 *Thank you for your consideration.*