### PR TITLE
add pip-upgrader in Package Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [pip](https://pip.pypa.io/en/stable/) - The Python package and dependency manager.
     * [Python Package Index](https://pypi.python.org/pypi)
-* [pip-upgrader](https://github.com/simion/pip-upgrader) - Interactive requirements upgrader, which also update the requirements.txt version
+* [pip-upgrader](https://github.com/simion/pip-upgrader) - Interactive requirements upgrader, which also updates the requirements.txt version
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [Curdling](http://clarete.li/curdling/) - Curdling is a command line tool for managing Python packages.
 * [pip-tools](https://github.com/nvie/pip-tools) - A set of tools to keep your pinned Python dependencies fresh.

--- a/README.md
+++ b/README.md
@@ -854,6 +854,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [pip](https://pip.pypa.io/en/stable/) - The Python package and dependency manager.
     * [Python Package Index](https://pypi.python.org/pypi)
+* [pip-upgrader](https://github.com/simion/pip-upgrader) - Interactive requirements upgrader, which also update the requirements.txt version
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [Curdling](http://clarete.li/curdling/) - Curdling is a command line tool for managing Python packages.
 * [pip-tools](https://github.com/nvie/pip-tools) - A set of tools to keep your pinned Python dependencies fresh.


### PR DESCRIPTION
## What is this Python project?

[pip-upgrader](https://github.com/simion/pip-upgrader) is an interactive pip requirements upgrader, which also updates the version in your `requirements.txt` file(s).
In other words, here's a small demonstration:
![pip-upgrade demo](https://raw.githubusercontent.com/simion/pip-upgrader/master/demo.gif)


## What's the difference between this Python project and similar ones?

You can use pip-tools to upgrade all your packages. But in real life, people don't upgrade ALL packages at one.  You'll probbaly need to upgrade packages one by one, run tests, check compatibility. That's why **pip-upgrader** exists.


--


Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
