### PR TITLE
Add tasktiger

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,6 +894,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [mrq](https://github.com/pricingassistant/mrq) - Mr. Queue - A distributed worker task queue in Python using Redis & gevent.
 * [rq](http://python-rq.org/) - Simple job queues for Python.
 * [simpleq](https://github.com/rdegges/simpleq) - A simple, infinitely scalable, Amazon SQS based queue.
+* [tasktiger](https://github.com/closeio/tasktiger) - Alternative to celery, redis based task queue
 
 ## RESTful API
 


### PR DESCRIPTION
## What is this Python project?

Alternative to celery with far less features but simplified

## What's the difference between this Python project and similar ones?

Celery, or any other task queue library

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
