### PR TITLE
added gREST to Flask (under RESTful API category)

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,6 +909,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [flask-api](http://www.flaskapi.org/) - Browsable Web APIs for Flask.
     * [flask-restful](https://github.com/flask-restful/flask-restful) - Quickly building REST APIs for Flask.
     * [flask-restless](https://github.com/jfinkels/flask-restless) - Generating RESTful APIs for database models defined with SQLAlchemy.
+    * [gREST](https://github.com/mostafa/grest) - Build REST APIs with Neo4j and Flask, as quickly as possible!
 * Pyramid
     * [cornice](https://github.com/mozilla-services/cornice) - A RESTful framework for Pyramid.
 * Framework agnostic


### PR DESCRIPTION
## What is this Python project?

gREST (Graph-based REST API Framework) is a RESTful API development framework on top of Python, Flask, Neo4j and Neomodel. Its primary purpose is to ease development of RESTful APIs with little effort and miminum amount of code. It has built-in user input validation, relationship handling and multiple serialization options (JSON, XML & YAML).

## What's the difference between this Python project and similar ones?

There are no similar projects built for this specific problem area.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
