### PR TITLE
Add pyenchant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [unidecode](https://pypi.python.org/pypi/Unidecode) - ASCII transliterations of Unicode text.
     * [uniout](https://github.com/moskytw/uniout) - Print readable chars instead of the escaped string.
     * [xpinyin](https://github.com/lxneng/xpinyin) - A library to translate Chinese hanzi (漢字) to pinyin (拼音).
+    * [pyenchant](https://github.com/rfk/pyenchant) - Python bindings for the Enchant (AbiWord) spellchecker
 * Slugify
     * [awesome-slugify](https://github.com/dimka665/awesome-slugify) - A Python slugify library that can preserve unicode.
     * [python-slugify](https://github.com/un33k/python-slugify) - A Python slugify library that translates unicode to ASCII.


### PR DESCRIPTION
## What is this Python project?

*taken from their docs:*

**pyenchant** provides a set of Python language bindings for the **Enchant** spellchecking library.

> Enchant aims to provide a simple but comprehensive abstraction for dealing with different spell checking libraries in a consistent way. A client, such as a text editor or word processor, need not know anything about a specific spell-checker, and since all back-ends are plugins, new spell-checkers can
be added without needing any change to the program using Enchant.


## What's the difference between this Python project and similar ones?

 - Based on a clib
 - Works with different spell-checkers

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
