### PR TITLE
add PyPInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [PathPicker](https://github.com/facebook/PathPicker) - Select files out of bash output.
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.
     * [pgcli](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting.
+    * [PyPInfo](https://github.com/ofek/pypinfo) - Easily view PyPI download statistics via Google's BigQuery.
     * [SAWS](https://github.com/donnemartin/saws) - A Supercharged AWS CLI.
     * [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
     * [try](https://github.com/timofurrer/try) - A dead simple CLI to try out python packages - It's never been easier.


### PR DESCRIPTION
@vinta

## What is this Python project?

A pure Python CLI to view projects' download statistics. The supported fields are: project, version, pyversion, percent3, percent2, impl, impl-version, openssl, date, month, year, country, installer, installer-version, setuptools-version, system, system-release, distro, distro-version, and cpu. You can specify how many days in the past to consider or supply a custom date range. Custom ordering and where clauses are also supported.

Examples: https://github.com/ofek/pypinfo#usage

## What's the difference between this Python project and similar ones?

https://pypi.python.org/pypi/vanity

This uses an outdated (and not guaranteed to work) method of collecting statistics (by scraping PyPI). Also, it can only get the download counts.

https://pypi.python.org/pypi/pypi-download-stats

This requires users to write their own queries. It depends on a deprecated library to interface with BigQuery https://github.com/google/google-api-python-client/#library-maintenance. Also, the package depends on https://github.com/bokeh/bokeh which requires a complicated installation of NumPy and its scientific libs, and Tornado and its web server.

Both are GPL'd unfortunately while PyPInfo is licensed under MIT.