### PR TITLE
added mistletoe under Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [ReportLab](http://www.reportlab.com/opensource/) - Allowing Rapid creation of rich PDF documents.
 * Markdown
     * [Mistune](https://github.com/lepture/mistune) - Fastest and full featured pure Python parsers of Markdown.
+    * [mistletoe](https://github.com/miyuchina/mistletoe) - A fast, extensible Markdown parser in pure Python.
     * [Python-Markdown](https://github.com/waylan/Python-Markdown) - A Python implementation of John Gruber’s Markdown.
 * YAML
     * [PyYAML](http://pyyaml.org/) - YAML implementations for Python.


### PR DESCRIPTION
## What is this Python project?

mistletoe is a fast and extensible Markdown parser implementation.

## What's the difference between this Python project and similar ones?

* Compared to [Python-Markdown](https://github.com/waylan/Python-Markdown), it is over 4 times faster. With CPython its speed is on par with mistune.
* Compared to [Mistune](https://github.com/lepture/mistune), it is:
    - more flexible, in that adding parsing rules are formalized, easier and less brittle (see the GitHub Wiki [example](https://github.com/miyuchina/mistletoe#developers-guide) as compared to Mistune);
    - more extensible, in that writing new renderers are trivial (supports transpiling to LaTeX out of the box; also see [this example](https://github.com/miyuchina/mistletoe/blob/master/plugins/mathjax.py) where mathjax support is added to mistletoe);
    - about 2x faster when PyPy is used (see the [performance](https://github.com/miyuchina/mistletoe#performance) section);

See also: [why mistletoe?](https://github.com/miyuchina/mistletoe#why-mistletoe)

---

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.