### PR TITLE
Add "doubledouble" library

### DIFF
--- a/README.md
+++ b/README.md
@@ -943,6 +943,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [bccb](https://github.com/chapmanb/bcbb) - Collection of useful code related to biological analysis.
 * [Biopython](http://biopython.org/wiki/Main_Page) - Biopython is a set of freely available tools for biological computation.
 * [cclib](http://cclib.github.io/) - A library for parsing and interpreting the results of computational chemistry packages.
+* [doubledouble](https://github.com/sukop/doubledouble/) - Library for computing with unevaluated sums of two double precision floating-point numbers.
 * [NetworkX](https://networkx.github.io/) - A high-productivity software for complex networks.
 * [NIPY](http://nipy.org) - A collection of neuroimaging toolkits.
 * [NumPy](http://www.numpy.org/) - A fundamental package for scientific computing with Python.


### PR DESCRIPTION
## What is this Python project?

doubledouble.py is a library for computing with unevaluated sums of two double
precision floating-point numbers.

Enumerate comparisons.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
