### PR TITLE
Add RPC clients category and Zeep as SOAP client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     - [Queue](#queue)
     - [Recommender Systems](#recommender-systems)
     - [RESTful API](#restful-api)
+    - [RPC Clients](#rpc-clients)
     - [RPC Servers](#rpc-servers)
     - [Science](#science)
     - [Search](#search)
@@ -925,6 +926,12 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [restless](https://github.com/toastdriven/restless) - Framework agnostic REST framework based on lessons learned from Tastypie.
     * [ripozo](https://github.com/vertical-knowledge/ripozo) - Quickly creating REST/HATEOAS/Hypermedia APIs.
     * [sandman](https://github.com/jeffknupp/sandman) - Automated REST APIs for existing database-driven systems.
+
+## RPC Clients
+
+*Clients for various RPC protocols.*
+
+* [Zeep](http://docs.python-zeep.org/en/master/) - A fast, modern, and painless SOAP client. Supports Python 2 and 3.
 
 ## RPC Servers
 


### PR DESCRIPTION
## What is this Python project?

[Zeep](https://github.com/mvantellingen/python-zeep) is a painless client for SOAP, that supports Python 3 and is actually maintained.
I know that SOAP is bad, old, etc., but you still need it for some "enterprise" APIs that you may find in the wild.

Also, I created a category broader than just SOAP for things like Thrift and other protocols that maybe aren't as popular as HTTP.

## What's the difference between this Python project and similar ones?

* Has a very nice API that allows you to read and pass SOAP objects without the need of instantiating many Java-like objects. You can simply used (possibly nested) dictionaries.
* I think that only [Rinse](https://github.com/tysonclugg/rinse) supports Python 3, but it hasn't seen commits in some time.
* The rest only supports Python 2.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach 20.