### PR TITLE
Add Habu - Python Network Hacking Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [pyzmq](http://zeromq.github.io/pyzmq/) - A Python wrapper for the ZeroMQ message library.
 * [Twisted](https://twistedmatrix.com/trac/) - An event-driven networking engine.
 * [txZMQ](https://github.com/smira/txZMQ) - Twisted based wrapper for the ZeroMQ message library.
+* [habu](https://github.com/portantier/habu) - Python Network Hacking Toolkit
 
 ## News Feed
 


### PR DESCRIPTION
## What is this Python project?

I'm developing Habu to teach (and learn) some concepts about Python and Network Hacking.

These are basic functions that help with some tasks for Ethical Hacking and Penetration Testing.

Most of them are related with networking, and the implementations are intended to be understandable for who wants to read the source code and learn from that.

Some techniques implemented in the current version are:

    ARP Poisoning
    ARP Sniffing
    DHCP Discover
    DHCP Starvation
    LAND Attack
    SNMP Cracking
    SYN Flooding
    TCP Flags Analysis
    TCP ISN Analysis
    TCP Port Scan

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
