### PR TITLE
Added django-geojson

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for geocoding addresses and working with latitudes and longitudes.*
 
 * [django-countries](https://github.com/SmileyChris/django-countries) - A Django app that provides country choices for use with forms, flag icons static files, and a country field for models.
+
+* [django-geojson](https://github.com/makinacorpus/django-geojson) - A collection of helpers to (de)serialize (Geo)Django objects into GeoJSON.
 * [GeoDjango](https://docs.djangoproject.com/en/dev/ref/contrib/gis/) - A world-class geographic web framework.
 * [GeoIP](https://github.com/maxmind/geoip-api-python) - Python API for MaxMind GeoIP Legacy Database.
 * [geojson](https://github.com/frewsxcv/python-geojson) - Python bindings and utilities for GeoJSON.


### PR DESCRIPTION
## What is this Python project?
_django-geojson_ is a set of tools to manipulate GeoJSON with Django

## What's the difference between this Python project and similar ones?

Key features of _django-geojson_:

- (De)Serializer for (Geo)Django objects, querysets and lists
- Base views to serve GeoJSON map layers from models
- GeoJSON model and form fields to avoid spatial database backends (compatible with django-leaflet for map widgets)

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
