### PR TITLE
Adding Mocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [httmock](https://github.com/patrys/httmock) - A mocking library for requests for Python 2.6+ and 3.2+.
     * [httpretty](https://github.com/gabrielfalcao/HTTPretty) - HTTP request mock tool for Python.
     * [mock](https://docs.python.org/3/library/unittest.mock.html) - (Python standard library) A mocking and patching library.
+    * [Mocket](https://github.com/mindflayer/python-mocket) - Socket Mock Framework plus HTTP[S]/asyncio/gevent mocking library with recording/replaying capability.
     * [responses](https://github.com/getsentry/responses) - A utility library for mocking out the requests Python library.
     * [VCR.py](https://github.com/kevin1024/vcrpy) - Record and replay HTTP interactions on your tests.
 * Object Factories


### PR DESCRIPTION
## What is this Python project?

It’s a framework, actually a socket mock framework, and the proof of its reliability as framework is that both the HTTP mocking module (à la HTTPretty) and the basic Redis mock have been implemented using Mocket, and nothing more than that.

## What's the difference between this Python project and similar ones?

- It has SSL support, and of course HTTPS if we talk about its HTTP mock.
- It works well with others (e.g. pytest fixtures is one example, pook is another).
- It supports PyPy, gevent and asyncio/aiohttp.
- It dumps (as JSON files) everything that calls the sendall function on a true socket (recording functionality à la vcrpy).
- It strongly supports Python 3, since the very beginning. And yes, it’s definitely a big feature (ask HTTPretty users to better understand what does “supporting Py3” mean).
- Its APIs never changed. Frameworks should care about backward compatibility, and Mocket take it seriously.
- ~100% test coverage. Yes, that’s another important feature.
- HTTPretty compatibility layer (regex urls and body as function missing)

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
