### PR TITLE
Adding satchmo to e-commerce section

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [money](https://github.com/carlospalol/money) - Money class with optional CLDR-backed locale-aware formatting and an extensible currency exchange solution.
 * [python-currencies](https://github.com/Alir3z4/python-currencies) - Display money format and its filthy currencies.
 * [forex-python](https://github.com/MicroPyramid/forex-python) - Foreign exchange rates, Bitcoin price index and currency conversion.
+* [satchmo](https://bitbucket.org/chris1610/satchmo/wiki/Home) - An open source E-commerce platform created in Django.
 * [shoop](https://www.shuup.com/en/) - An open source E-Commerce platform based on Django.
 
 ## Editor Plugins and IDEs


### PR DESCRIPTION
## What is this Python project?

Satchmo is an e-commerce framework created in Django which allows you to develop unique and robust online stores. The project has an end to end integration from inventory management, multiple payment modules, and shipping providers.

## What's the difference between this Python project and similar ones?

Unlike most other e-commerce platforms in Django, it supports inbuild support for digital products which can be downloaded and subscription-based products.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
