### PR TITLE
Add deoplete-jedi as autocomplete source for vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [SublimeJEDI](https://github.com/srusskih/SublimeJEDI) - A Sublime Text plugin to the awesome auto-complete library Jedi.
 * Vim
     * [Jedi-vim](https://github.com/davidhalter/jedi-vim) - Vim bindings for the Jedi auto-completion library for Python.
+    * [deoplete-jedi](deoplete-jedi) - Bindings for async auto-completion engine Deoplete for Jedi auto-completion library for Python
     * [Python-mode](https://github.com/python-mode/python-mode) - An all in one plugin for turning Vim into a Python IDE.
     * [YouCompleteMe](https://github.com/Valloric/YouCompleteMe) - Includes [Jedi](https://github.com/davidhalter/jedi)-based completion engine for Python.
 * Visual Studio


### PR DESCRIPTION
## What is this Python project?

A source for deoplete autocompletion engine for vim

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
