### PR TITLE
Add Django-channels to WebSocket section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,6 +1220,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [AutobahnPython](https://github.com/crossbario/autobahn-python) - WebSocket & WAMP for Python on Twisted and [asyncio](https://docs.python.org/3/library/asyncio.html).
 * [Crossbar](https://github.com/crossbario/crossbar/) - Open-source Unified Application Router (Websocket & WAMP for Python on Autobahn).
+* [django-channels](https://github.com/django/channels) - Developer-friendly asynchrony for Django
 * [django-socketio](https://github.com/stephenmcd/django-socketio) - WebSockets for Django.
 * [WebSocket-for-Python](https://github.com/Lawouach/WebSocket-for-Python) - WebSocket client and server library for Python 2 and 3 as well as PyPy.
 


### PR DESCRIPTION
## What is this Python project?

The project is meant to allow Django to support HTTP/2, WebSockets or other protocols with ease.

## What's the difference between this Python project and similar ones?

Channels is an official Django Project. Now actively supported, probably should be in next Django releases.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.