### PR TITLE
Add EliteQuant backtest and live trading framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [SymPy](https://github.com/sympy/sympy) - A Python library for symbolic mathematics.
 * [Zipline](https://github.com/quantopian/zipline) - A Pythonic algorithmic trading library.
 * [SimPy](https://bitbucket.org/simpy/simpy) -  A process-based discrete-event simulation framework.
+* [EliteQuant](https://github.com/EliteQuant/EliteQuant_Python) - A unified backtest and live trading framework
 
 ## Search
 


### PR DESCRIPTION
In Science section

## What is this Python project?

It's a unified backtest and live trading platform

## What's the difference between this Python project and similar ones?

1. Write once and easy switch between backtest and live trading
2. Share the same structure and performance measures across languages, making it easier to compare and communicate with traders speaking other languages such as R and Matlab.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
