### PR TITLE
Fixed link and description for Sentry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Eliot](https://github.com/ScatterHQ/eliot) - Logging for complex & distributed systems.
 * [logbook](http://logbook.readthedocs.io/en/stable/) - Logging replacement for Python.
 * [logging](https://docs.python.org/2/library/logging.html) - (Python standard library) Logging facility for Python.
-* [Sentry](https://pypi.python.org/pypi/sentry) - A realtime logging and aggregation server.
+* [raven](https://github.com/getsentry/raven-python) - Python client for Sentry, a log/error tracking, crash reporting and aggregation platform for web applications.
 
 ## Machine Learning
 


### PR DESCRIPTION
Not adding anything - just fixing an existing entry @vinta 

It makes more sense to include the Python client to Sentry, `raven`, than include the server software itself. I've made the appropriate change to the link and also updated the description as per https://github.com/getsentry/sentry and https://sentry.io/welcome.

