### PR TITLE
Add 'deco' library

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [threading](https://docs.python.org/2/library/threading.html) - (Python standard library) Higher-level threading interface.
 * [Tomorrow](https://github.com/madisonmay/Tomorrow) - Magic decorator syntax for asynchronous code.
 * [uvloop](https://github.com/MagicStack/uvloop) - Ultra fast implementation of asyncio event loop on top of libuv.
+* [deco](https://github.com/alex-sherman/deco) - A simplified parallel computing model using decorators.
 
 ## Configuration
 


### PR DESCRIPTION
* 'deco' library makes parallelizing easy by giving us decorators
  which encapsulates multiprocessing standard library.

## What is this Python project?
A simplified parallel computing model for Python. DECO automatically parallelizes Python programs, and requires minimal modifications to existing serial programs.

## What's the difference between this Python project and similar ones?
It is similar to Tomorrow, but has the following differences.

1. `Deco` supports Python3, whereas `Tomorrow` supports only up till Python 2.7
2. `Deco` by default uses the Python's **multiprocessing** library, whereas `Tomorrow` uses **threads**
--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
