### PR TITLE
Added quandl-metabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Pygal](http://www.pygal.org/en/latest/) - A Python SVG Charts Creator.
 * [PyGraphviz](https://pypi.python.org/pypi/pygraphviz) - Python interface to [Graphviz](http://www.graphviz.org/).
 * [PyQtGraph](http://www.pyqtgraph.org/) - Interactive and realtime 2D/3D/Image plotting and science/engineering widgets.
+* [quandl-metabase](https://hasura.io/hub/project/anirudhm/quandl-metabase-time-series) - Visualize Quandl's timeseries datasets with Metabase.
 * [Seaborn](https://github.com/mwaskom/seaborn) - Statistical data visualization using Matplotlib.
 * [VisPy](https://github.com/vispy/vispy) - High-performance scientific visualization based on OpenGL.
 


### PR DESCRIPTION
## What is this Python project?

This quickstart project, built with Python makes use of Metabase library to visualize the datasets from Quandl.

## What's the difference between this Python project and similar ones?

Quandl offers a set of tools to visualize their datasets (https://www.quandl.com/tools/full-list). [Metabase](https://github.com/metabase/metabase) is open-source, fast, and makes it so easy to share data and analytics. This Hasura quickstart project [hasura/quandl-metabase](https://github.com/anirudhmurali/Quandl-Metabase) makes use of Metabase to visualize quandl's datasets.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
