### PR TITLE
Add IMAPClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [envelopes](http://tomekwojcik.github.io/envelopes/) - Mailing for human beings.
 * [flanker](https://github.com/mailgun/flanker) - A email address and Mime parsing library.
+* [IMAPClient](https://github.com/mjs/imapclient) - An easy-to-use, Pythonic and complete IMAP client library.
 * [imbox](https://github.com/martinrusev/imbox) - Python IMAP for Humans.
 * [inbox.py](https://github.com/kennethreitz/inbox.py) - Python SMTP Server for Humans.
 * [lamson](https://github.com/zedshaw/lamson) - Pythonic SMTP Application Server.


### PR DESCRIPTION
## What is this Python project?

A client library for the IMAP protocol.

## What's the difference between this Python project and similar ones?

- Has been around for about 10 years and is still maintained and being modernized
- More Pythonic than `imaplib` provided in the standard library
- Seems to support more extension RFCs than `imbox`

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
