### PR TITLE
add PubDNS library

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [blinker](https://github.com/jek/blinker) - A fast Python in-process signal/event dispatching system.
 * [itsdangerous](https://github.com/pallets/itsdangerous) - Various helpers to pass trusted data to untrusted environments.
 * [pluginbase](https://github.com/mitsuhiko/pluginbase) - A simple but flexible plugin system for Python.
+* [PubDNS](https://github.com/mehrdadrad/pubdns) - A Python library to interact with thousands of public DNS servers around the world.
 * [Pychievements](https://github.com/PacketPerception/pychievements) - A framework for creating and tracking achievements.
 * [Tryton](http://www.tryton.org/) - A general purpose business framework.
 


### PR DESCRIPTION
## What is this Python project?

Python library to interact with 28K public DNS servers around the world

pubdns is a library for python to have more than 28K public dns servers from 190+ countries at your python script. it works based on the public-dns.info collected data and there is a wrapper based on the dnspython to resolve all type of dns records through these public dns server smoothly.

## What's the difference between this Python project and similar ones?

I haven't seen similar one in python language if exist!

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
