### PR TITLE
Added MonkeyType to 'Code Analysis and Linter'

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [Pylint](https://www.pylint.org/) - A Fully customizable source code analyzer.
 * Static Type Checker
     * [mypy](http://mypy-lang.org/) - Check variable types during compile time.
+* Static Type Annotations Generators
+    * [MonkeyType](https://github.com/Instagram/MonkeyType) - A system for Python that generates static type annotations by collecting runtime types
 
 ## Command-line Tools
 


### PR DESCRIPTION
## What is this Python project?

It generates static type annotations by collecting runtime types. After collection is done it can insert generated stubs into your code.

## What's the difference between this Python project and similar ones?

- compared to [pyannotate](https://github.com/dropbox/pyannotate) it has Python3 support;
- compared to [pyannotate](https://github.com/dropbox/pyannotate) it does not need [special pytest plugin](https://github.com/kensho-technologies/pytest-annotate): ```monkeytype run `which pytest` ``` is enough;
- pyannotate is the Dropbox project, MonkeyType is the Instagram project;
- it stores analysis results in sqlite format.

PS. Neither `pyannotate` nor `pytest-annotate` is in this list, but I follow the contribution rule `1pr == 1 link`.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
