### PR TITLE
Add trafaret library

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Schematics](https://github.com/schematics/schematics) - Data Structure Validation.
 * [valideer](https://github.com/podio/valideer) - Lightweight extensible data validation and adaptation library.
 * [voluptuous](https://github.com/alecthomas/voluptuous) - A Python data validation library.
+* [trafaret](https://github.com/Deepwalker/trafaret) - Ultimate transformation library that supports validation, contexts and aiohttp.
 
 ## Data Visualization
 


### PR DESCRIPTION
## What is this Python project?

Trafaret is a validation + conversion library. The main distinct feature of Trafaret is composability.
From base Trafaret transformers and simple functions you can construct transformer of any complexity. And dict validation is not corner stone of this library.

## What's the difference between this Python project and similar ones?

There is no actually similar projects or I don't know about. Trafaret is simple and yet powerful, because of monads inside, sorry. It does not count dict as a only thing that is need care about, offer strong API first and some sugar on top of strong foundation.

To combine two trafarets you just do `trafaret1 & trafaret2`, or even `trafaret1 | trafaret2`. And any single argument function can be treated as trafaret if it raises trafaret.DataError or return value.