### PR TITLE
Add IceCream to Debugging Tools/Other.

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [profiling](https://github.com/what-studio/profiling) - An interactive Python profiler.
     * [vprof](https://github.com/nvdv/vprof) - Visual Python profiler.
 * Others
+    * [IceCream](https://github.com/gruns/icecream) - Inspect variables, expressions, and program execution with a single, simple function call.
     * [django-debug-toolbar](https://github.com/jazzband/django-debug-toolbar) - Display various debug information for Django.
     * [django-devserver](https://github.com/dcramer/django-devserver) - A drop-in replacement for Django's runserver.
     * [flask-debugtoolbar](https://github.com/mgood/flask-debugtoolbar) - A port of the django-debug-toolbar to flask.


### PR DESCRIPTION
## What is this Python project?

IceCream is a small Python library that makes it easy to debug variables,
expressions, and code execution with a single, simple function: `ic()`. (short
for IceCream)

With arguments, `ic()` inspects itself and prints both its own arguments and
those argument's values.

```python
from icecream import ic

def foo(i):
    return i + 333

ic(foo(123))
```

Prints

```
ic| foo(123): 456
```

Without arguments, `ic()` inspects itself and prints the calling filename and
line number.

```python
from icecream import ic

def foo():
    ic()
    return 'bar'

foo()
```

Prints

```
ic| example.py:4 in foo()
```

See more IceCream magic and examples in IceCream's docs, [here](https://github.com/gruns/icecream).

IceCream is well tested, permissively licensed, and supports Python 2, Python 3,
PyPy2, and PyPy3.


## What's the difference between this Python project and similar ones?

IceCream's closest cousin is q (https://github.com/zestyping/q), but IceCream is
simpler, customizable, and actively maintained.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to
it, and usually, the maintainer will merge it when votes reach **20**.
