### PR TITLE
Add django-admin-interface to Admin panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for administrative interfaces.*
 
 * [Ajenti](https://github.com/ajenti/ajenti) - The admin panel your servers deserve.
+* [django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface) - Customizable responsive admin interface, popup windows replaced by modals.
 * [django-suit](http://djangosuit.com/) - Alternative Django Admin-Interface (free only for Non-commercial use).
 * [django-xadmin](https://github.com/sshwsfc/xadmin) - Drop-in replacement of Django admin comes with lots of goodies.
 * [flask-admin](https://github.com/flask-admin/flask-admin) - Simple and extensible administrative interface framework for Flask.


### PR DESCRIPTION
## What is this Python project?

[django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface) is a customizable responsive admin interface, based on a modern flat theme, it lets you customize the admin title, logo and colors by the admin itself. Popup windows replaced by modals.

![django-admin-interface-preview](https://user-images.githubusercontent.com/1035294/35631521-64b0cab8-06a4-11e8-8f57-c04fdfbb7e8b.gif)

## What's the difference between this Python project and similar ones?

It improves the default admin interface without replacing it.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
