### PR TITLE
add packerlicious - packer template generation in python

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Fabtools](https://github.com/fabtools/fabtools) - Tools for writing awesome Fabric files.
 * [honcho](https://github.com/nickstenning/honcho) - A Python clone of [Foreman](https://github.com/ddollar/foreman), for managing Procfile-based applications.
 * [OpenStack](https://www.openstack.org/) - Open source software for building private and public clouds.
+* [packerlicious](https://github.com/mayn/packerlicious) - A library for generating packer templates.
 * [pexpect](https://github.com/pexpect/pexpect) - Controlling interactive programs in a pseudo-terminal like GNU expect.
 * [psutil](https://github.com/giampaolo/psutil) - A cross-platform process and system utilities module.
 * [SaltStack](https://github.com/saltstack/salt) - Infrastructure automation and management system.


### PR DESCRIPTION
## What is this Python project?

[packerlicious](https://github.com/mayn/packerlicious) is a python library to create [packer](https://github.com/hashicorp/packer) templates in python.

example usage:
```
from packerlicious import builder, provisioner, Template

template = Template()
template.add_builder(
    builder.AmazonEbs(
        access_key="...",
        secret_key="...",
        region="us-east-1",
        source_ami="ami-fce3c696",
        instance_type="t2.micro",
        ssh_username="ubuntu",
        ami_name="packer {{timestamp}}"
    )
)

template.add_provisioner(
    provisioner.Shell(
        script="setup_things.sh"
    )
)

print(template.to_json())
```

resulting packer template:
```
    {
      "builders": [
        {
          "access_key": "...",
          "ami_name": "packer {{timestamp}}",
          "instance_type": "t2.micro",
          "region": "us-east-1",
          "secret_key": "...",
          "source_ami": "ami-fce3c696",
          "ssh_username": "ubuntu",
          "type": "amazon-ebs"
        }
      ],
      "provisioners": [
        {
          "script": "setup_things.sh",
          "type": "shell"
        }
      ]
    }
```

## What's the difference between this Python project and similar ones?

- only one that supports expressing packer templates in python

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
