### PR TITLE
Add poetry to Package Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [Curdling](http://clarete.li/curdling/) - Curdling is a command line tool for managing Python packages.
 * [pip-tools](https://github.com/jazzband/pip-tools) - A set of tools to keep your pinned Python dependencies fresh.
+* [poetry](https://github.com/sdispater/poetry) - Python dependency management and packaging made easy.
 * [wheel](http://pythonwheels.com/) - The new standard of Python distribution and are intended to replace eggs.
 
 ## Package Repositories


### PR DESCRIPTION
## What is this Python project?

Poetry helps you declare, manage and install dependencies of Python projects, ensuring you have the right stack everywhere.

## What's the difference between this Python project and similar ones?

poetry is a tool to handle dependencies installation, building and packaging of Python packages. It only needs one file to do all of that: the new, standardized `pyproject.toml`.

Here are some of the features that make it stand out:

* Exhaustive dependency resolver
* Intuitive CLI (See https://poetry.eustace.io/docs/cli/)
* Emphasis on semantic versioning and constraint specification so that wildcard dependencies (`*`) will be considered bad practice
* Support for dependencies caret, tilde, wildcard, inequality and multiple requirements.
* Only one file: the standardised pyproject.toml which aims at being readable and clear.
* Mandatory compatible python versions specification.

For more information: https://github.com/sdispater/poetry or http://poetry.eustace.io

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
