### PR TITLE
Add pip-compile-multi

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [Curdling](http://clarete.li/curdling/) - Curdling is a command line tool for managing Python packages.
 * [pip-tools](https://github.com/jazzband/pip-tools) - A set of tools to keep your pinned Python dependencies fresh.
+* [pip-compile-multi](https://github.com/peterdemin/pip-compile-multi) - User-oriented pip-tools enhancement to work with multiple requirements files.
 * [wheel](http://pythonwheels.com/) - The new standard of Python distribution and are intended to replace eggs.
 
 ## Package Repositories


### PR DESCRIPTION
## What is this Python project?

It's a command-line tool to lock, upgrade and verify requirements files. It's built on top of pip-tools and enhances it.

## What's the difference between this Python project and similar ones?

It's similar to pip-tools, but automates multiple common tasks, like running for multiple files, using compatible releases and such.
PipEnv is another similar tool that is built on top of pip-tools, but that one introduces new format and doesn't support Python < 3.6 and more than two environments.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
