### PR TITLE
Added rebound to command-line tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [PathPicker](https://github.com/facebook/PathPicker) - Select files out of bash output.
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.
     * [pgcli](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting.
+    * [rebound](https://github.com/shobrook/rebound) - Command-line tool that instantly fetches Stack Overflow results when you get a compiler error.
     * [SAWS](https://github.com/donnemartin/saws) - A Supercharged AWS CLI.
     * [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
     * [tmuxp](https://github.com/tony/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.


### PR DESCRIPTION
## What is this Python project?

`Rebound` is a command-line tool that instantly fetches Stack Overflow results when you get a compiler error.

## What's the difference between this Python project and similar ones?

The only similar ones are `how2` and `socli`, which are command-line clients for browsing Stack Overflow. `Rebound` is different because it automatically pulls an error message and keywords from the stack trace, creates a search query, and displays the most relevant SO results in the terminal. It also has the same functionality as `how2` and `socli`, if the user chooses.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
