### PR TITLE
Please add Lomond to the WebSocket section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [AutobahnPython](https://github.com/crossbario/autobahn-python) - WebSocket & WAMP for Python on Twisted and [asyncio](https://docs.python.org/3/library/asyncio.html).
 * [Crossbar](https://github.com/crossbario/crossbar/) - Open-source Unified Application Router (Websocket & WAMP for Python on Autobahn).
+* [Lomond](https://github.com/wildfoundry/dataplicity-lomond) - Easy to use WebSocket client for Python2 and 3.
 * [django-channels](https://github.com/django/channels) - Developer-friendly asynchrony for Django
 * [django-socketio](https://github.com/stephenmcd/django-socketio) - WebSockets for Django.
 * [WebSocket-for-Python](https://github.com/Lawouach/WebSocket-for-Python) - WebSocket client and server library for Python 2 and 3 as well as PyPy.

--- a/README.md
+++ b/README.md
@@ -1242,9 +1242,9 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [AutobahnPython](https://github.com/crossbario/autobahn-python) - WebSocket & WAMP for Python on Twisted and [asyncio](https://docs.python.org/3/library/asyncio.html).
 * [Crossbar](https://github.com/crossbario/crossbar/) - Open-source Unified Application Router (Websocket & WAMP for Python on Autobahn).
-* [Lomond](https://github.com/wildfoundry/dataplicity-lomond) - Easy to use WebSocket client for Python2 and 3.
 * [django-channels](https://github.com/django/channels) - Developer-friendly asynchrony for Django
 * [django-socketio](https://github.com/stephenmcd/django-socketio) - WebSockets for Django.
+* [Lomond](https://github.com/wildfoundry/dataplicity-lomond) - Easy to use WebSocket client for Python2 and 3.
 * [WebSocket-for-Python](https://github.com/Lawouach/WebSocket-for-Python) - WebSocket client and server library for Python 2 and 3 as well as PyPy.
 
 # Services


### PR DESCRIPTION
## What is this Python project?

Lomond is a WebSocket client designed for ease of use.

## What's the difference between this Python project and similar ones?

Lomond exposes WebSocket interactions with an iterator of events, which is often easier to reason about than the callback approach taken by most WebSocket libraries.

This library is well tested with 100% coverage, and commercially sponsored. 

Here's an example that streams Bitcoin prices.

```python
from lomond import WebSocket
websocket = WebSocket('wss://ws-feed.gdax.com')

for event in websocket:
    if event.name == "ready":
        websocket.send_json(
            type='subscribe',
            product_ids=['BTC-USD'],
            channels=['ticker']
        )
    elif event.name == "text":
        print(event.json)
```

More information [here](https://www.willmcgugan.com/blog/tech/post/announcing-lomond/)

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
