### PR TITLE
Add Pottery to NoSQL Databases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [cassandra-python-driver](https://github.com/datastax/python-driver) - Python driver for Cassandra.
     * [HappyBase](https://github.com/wbolster/happybase) - A developer-friendly library for Apache HBase.
     * [Plyvel](https://github.com/wbolster/plyvel) - A fast and feature-rich Python interface to LevelDB.
+    * [Pottery](https://github.com/brainix/pottery) - High level Pythonic dict, set, and list like containers around Redis data types.
     * [py2neo](http://py2neo.org/2.0/) - Python wrapper client for Neo4j's restful interface.
     * [pycassa](https://github.com/pycassa/pycassa) - Python Thrift driver for Cassandra.
     * [PyMongo](https://docs.mongodb.com/ecosystem/drivers/python/) - The official Python client for MongoDB.


### PR DESCRIPTION
## What is this Python project?

[Pottery](https://github.com/brainix/pottery) is a Pythonic way to access Redis.  If you know how to use Python dicts, then you already know how to use Pottery.

## What's the difference between this Python project and similar ones?

Other Redis clients stay close to the [Redis command set](https://redis.io/commands), but Pottery provides container classes to access Redis that implement the various Python container APIs.  Under the hood, Pottery uses [redis-py](https://github.com/andymccurdy/redis-py), but Pottery provides:

- a [dict API](https://github.com/brainix/pottery#dicts) to access [Redis Hashes](https://redis.io/commands#hash)
- a [set API](https://github.com/brainix/pottery#sets) to access [Redis Sets](https://redis.io/commands#set)
- a [list API](https://github.com/brainix/pottery#lists) to access [Redis Lists](https://redis.io/commands#list)
- a [distributed ID generator](https://github.com/brainix/pottery#nextid)
- a [distributed lock](https://github.com/brainix/pottery#redlock) that implements the [`threading.Lock`](https://docs.python.org/3/library/threading.html#lock-objects) API
- a [timer](https://github.com/brainix/pottery#contexttimer) to accurately measure code execution time
- a [Bloom filter](https://github.com/brainix/pottery#bloom-filters) that implements the set API, backed by Redis

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
