### PR TITLE
Add Acra, database protection suite [security]

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     - [Data Visualization](#data-visualization)
     - [Database Drivers](#database-drivers)
     - [Database](#database)
+    - [Database-tools](#database-tools)
     - [Date and Time](#date-and-time)
     - [Debugging Tools](#debugging-tools)
     - [Deep Learning](#deep-learning)
@@ -407,6 +408,12 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [redis-py](https://github.com/andymccurdy/redis-py) - The Redis Python Client.
     * [telephus](https://github.com/driftx/Telephus) - Twisted based client for Cassandra.
     * [txRedis](https://github.com/deldotdr/txRedis) - Twisted based client for Redis.
+
+## Database Tools
+
+*Libraries and tools for database-based applications. *
+
+* [Acra](https://github.com/cossacklabs/acra) - SQL database protection suite: strong selective encryption, SQL injections prevention, intrusion detection system.
 
 ## Date and Time
 


### PR DESCRIPTION
## What is this Python project?

[Acra](https://github.com/cossacklabs/acra) is a network encryption proxy to protect databases and database-based applications from data leaks, allowing greater security for distributed applications via cryptography and intrusion detection.

[AcraWriter](https://github.com/cossacklabs/acra/wiki/Using-Acra-to-Protect-Your-Django-App) is a part of Acra suite, a client-side library, which integrates into the app flow either through ORM or directly, and provides the means to encrypt the sensitive data.

## What's the difference between this Python project and similar ones?

Acra doesn't have similar projects, however you might think about Vault's Encryption as a Service engine, but deployed in your own infrastructure, without leaking keys anywhere.

- Acra allows to selectively encrypt sensitive records with strong multi-layer cryptography in client-side application. Client-side app doesn't have _decryption_ key, thus compromising app won't lead to stealing key and decrypting data in the database.
- Sensitive data is encrypted before being transmitted to the database, and decryption key is not stored on client side.
- Data is decrypted in trusted environment (on AcraServer).
- Acra allows to detect potential intrusions and SQL injections (using SQL firewall and poison records).
- Has SIEM integrations.
- Suits for distributed, microservice-rich environments.
- Has numerous examples and tutorials for Python client applications.
- Allows your application to cover GDPR articles 25, 32, 33, 34. 
- Tested, supported, audited.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
