### PR TITLE
Added PySimpleGUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [PyGObject](https://wiki.gnome.org/Projects/PyGObject) - Python Bindings for GLib/GObject/GIO/GTK+ (GTK+3).
 * [PyQt](https://riverbankcomputing.com/software/pyqt/intro) - Python bindings for the [Qt](https://www.qt.io/) cross-platform application and UI framework, with support for both Qt v4 and Qt v5 frameworks.
 * [PySide](https://wiki.qt.io/PySide) - Python bindings for the [Qt](http://www.qt.io/) cross-platform application and UI framework, supporting the Qt v4 framework.
+* [PySimpleGUI](https://github.com/MikeTheWatchGuy/PySimpleGUI) - Wrapper for tkinter that creates a more Python-like interface for beginner and intermediate level custom GUIs.
 * [pywebview](https://github.com/r0x0r/pywebview/) - A lightweight cross-platform native wrapper around a webview component that allows to display HTML content in its own native dedicated window.
 * [Tkinter](https://wiki.python.org/moin/TkInter) - Tkinter is Python's de-facto standard GUI package.
 * [Toga](https://github.com/pybee/toga) - A Python native, OS native GUI toolkit.


### PR DESCRIPTION
Added PySimpleGUI to the list of GUI frameworks.

It's a new package that enables creation of custom GUIs in very few lines of clear, easy to read Python code.

None of the other simplified GUI frameworks come close to this kind of design and ease of use.

## What is this Python project?

PySimpleGUI provides a way for beginners to build GUIs with little effort.  Customized GUIs can be built using Python lists in a few short minutes.  Results are returned via a list as well.  All typical GUI Widgets are available (checkboxes, radio buttons, buttons, text, etc)

## What's the difference between this Python project and similar ones?

- More Python-like than any other GUI package. Period.
- Same widgets as tkinter but presented in an easy to understand way
- No dependencies on other packages
- Single source file.... copy source PySimpleGUI.py should pip install not be feasable
- Easily understood by beginners (all of the others suck for beginning programmers or are too limited)

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
