### PR TITLE
add appkernel microservice framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [django-rest-framework](http://www.django-rest-framework.org/) - A powerful and flexible toolkit to build web APIs.
     * [django-tastypie](http://tastypieapi.org/) - Creating delicious APIs for Django apps.
 * Flask
+    * [appkernel](https://github.com/accelero-cloud/appkernel) - REST microservice framework powered by Flask, MongoDB and the belief that you love simplicity.
     * [eve](https://github.com/pyeve/eve) - REST API framework powered by Flask, MongoDB and good intentions.
     * [flask-api-utils](https://github.com/marselester/flask-api-utils) - Taking care of API representation and authentication for Flask.
     * [flask-api](http://www.flaskapi.org/) - Browsable Web APIs for Flask.


### PR DESCRIPTION
## What is this Python project?

[appkernel](https://github.com/accelero-cloud/appkernel) - A beautiful, well tested python framework helping you to deliver REST APIs from zero to production within minutes (no kidding: literally within minutes).

## What's the difference between this Python project and similar ones?

* Flask - it provides a lot more functionality out of the box, including security and ORM/ODM;
* Eve - the resource definition is in code, making it very natural for developers to extend it;
* Flask-Restful - more extended feature set, including serialization, validation, security and data encryption;
* Flask-Restless - focuses on MongoDB (instead of SQLAlchemy), provides value generators, fine-grained security features, HATEOAS, REST client with circuit breaker and many other planned features making the development of micro-services much easier;

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
