### PR TITLE
Add Pyxel

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,9 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [PyOgre](http://www.ogre3d.org/tikiwiki/PyOgre) - Python bindings for the Ogre 3D render engine, can be used for games, simulations, anything 3D.
 * [PyOpenGL](http://pyopengl.sourceforge.net/) - Python ctypes bindings for OpenGL and it's related APIs.
 * [PySDL2](http://pysdl2.readthedocs.io/en/rel_0_9_5/) - A ctypes based wrapper for the SDL2 library.
+* [Pyxel](https://github.com/kitao/pyxel) - A retro game development environment.
 * [RenPy](https://www.renpy.org/) - A Visual Novel engine.
+
 
 ## Geolocation
 


### PR DESCRIPTION
## What is this Python project?

As said in its own README

> Pyxel is a retro game development environment in Python.
Thanks to its simple specifications inspired by retro gaming consoles, such as only 16 colors can be displayed and only 4 sounds can be played back at the same time, you can feel free to enjoy making pixel art style games.

It's similar to fantasy consoles like PICO-8 or TIC-80.

## What's the difference between this Python project and similar ones?

Pyxel differ from the other projects by focusing on developing retro games imposing limitations, like the small sized color palette.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
