### PR TITLE
Add pyecharts

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [bqplot](https://github.com/bloomberg/bqplot) - Interactive Plotting Library for the Jupyter Notebook
 * [ggplot](https://github.com/yhat/ggpy) - Same API as ggplot2 for R.
 * [Matplotlib](http://matplotlib.org/) - A Python 2D plotting library.
+* [pyecharts](http://pyecharts.org) - Python interface for the [ECharts](https://github.com/apache/incubator-echarts) visualization library.
 * [Pygal](http://www.pygal.org/en/latest/) - A Python SVG Charts Creator.
 * [PyGraphviz](https://pypi.python.org/pypi/pygraphviz) - Python interface to [Graphviz](http://www.graphviz.org/).
 * [PyQtGraph](http://www.pyqtgraph.org/) - Interactive and realtime 2D/3D/Image plotting and science/engineering widgets.


### PR DESCRIPTION
## What is this Python project?

Pyecharts is a python interface to [Echarts.js](https://github.com/apache/incubator-echarts) visualization library. It supports [28+ charts ranging from 2D, 3D and geo mapping](http://nbviewer.jupyter.org/github/pyecharts/pyecharts-users-cases/blob/master/notebook-users-cases/notebook-user-cases.ipynb). It supports data scientists using Jupyter, [nteract](http://pyecharts.org/#/zh-cn/jupyter_notebook?id=nteract) and supports web developers with [django ](http://pyecharts.org/#/zh-cn/django)and [flask](http://pyecharts.org/#/zh-cn/flask) integration. 

## What's the difference between this Python project and similar ones?

It is similar to plotly.py and bokeh. 

Comparing with plotly.py, pyecharts offers free exports of svg, pdf and html format whereas plotly.py offer them under a premium version. And pyecharts does not really care about the number of exports to other file formats whereas ploly.py allows up to[100 exports per 24h](https://plot.ly/products/cloud/).

Comparing with bokeh, user group are different. Bokeh serves primarily scientific community whereas pyecharts serves both web developers and data analysts. Bokeh's api emulates matplotlib whereas pyecharts api emulates pygal. 

When it comes to geomapping, pyecharts has strong support for [Chinese regions](https://github.com/echarts-maps). 

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.