### PR TITLE
Add CxFreeze to the build section

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [py2exe](http://www.py2exe.org/) - Freezes Python scripts (Windows).
 * [PyInstaller](https://github.com/pyinstaller/pyinstaller) - Converts Python programs into stand-alone executables (cross-platform).
 * [pynsist](http://pynsist.readthedocs.io/en/latest/) - A tool to build Windows installers, installers bundle Python itself.
+* [cx_Freeze](https://anthony-tuininga.github.io/cx_Freeze/) - A tool to build Python executables for any platform.
 
 ## Documentation
 


### PR DESCRIPTION
## What is this Python project?

CxFreeze allows you to build python executable for every desktop platform (such as Linux, Windows or Mac).
This project is like pyinstaller or nuitka but it updates faster than first and builds in python (other than second).

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
 