### PR TITLE
added spurplus

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [pexpect](https://github.com/pexpect/pexpect) - Controlling interactive programs in a pseudo-terminal like GNU expect.
 * [psutil](https://github.com/giampaolo/psutil) - A cross-platform process and system utilities module.
 * [SaltStack](https://github.com/saltstack/salt) - Infrastructure automation and management system.
+* [spurplus](https://github.com/Parquery/spurplus) - Manages the remote machines via SSH including a rich set of file operations such as sync and mkdtemp. Built on top of paramiko and spur.
 * [supervisor](https://github.com/Supervisor/supervisor) - Supervisor process control system for UNIX.
 
 ## Distribution


### PR DESCRIPTION
## What is this Python project?

Manages the remote machines via SSH including a rich set of file operations such as sync and mkdtemp. Built on top of paramiko and spur.

## What's the difference between this Python project and similar ones?

Please see the github page for details on differences to Spur; the most important ones are:
* type annotations
* pathlib.Path support
* many helper functions to abstract away the tedious work with SFTP client
* sync function to sync a local to a remote directory (similar to rsync)
* computation of MD5 checksums
*  a wrapper around paramiko's SFTP client to automatically reconnect on failures

--
Anyone who agrees with this pull request could vote for it by adding a :+1:  to it, and usually, the maintainer will merge it when votes reach 20.