### PR TITLE
add safrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,6 +952,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [flask-api](http://www.flaskapi.org/) - Browsable Web APIs for Flask.
     * [flask-restful](https://github.com/flask-restful/flask-restful) - Quickly building REST APIs for Flask.
     * [flask-restless](https://github.com/jfinkels/flask-restless) - Generating RESTful APIs for database models defined with SQLAlchemy.
+    * [safrs](https://github.com/thomaxxl/safrs/) - Quickly deploy JSON:API services based on SQLAlchemy models with an OpenApi (fka Swagger) UI
 * Pyramid
     * [cornice](https://github.com/Cornices/cornice) - A RESTful framework for Pyramid.
 * Framework agnostic


### PR DESCRIPTION
[safrs](https://github.com/thomaxxl/safrs/) - Quickly deploy JSON:API services based on SQLAlchemy models with an OpenApi (fka Swagger) UI

## What is this Python project?

 The purpose of this framework is to help python developers create a self-documenting JSON API for sqlalchemy models
![demo](https://github.com/thomaxxl/safrs/raw/master/docs/images/safrs.gif)

## What's the difference between this Python project and similar ones?

- Automatically generate OpenApi-Spec (swagger) documentation
- JSON:API compliant

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
