### PR TITLE
Add aiochan

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [multiprocessing](https://docs.python.org/3/library/multiprocessing.html) - (Python standard library) A high-level interface for asynchronously executing callables.
 * [eventlet](http://eventlet.net/) - Asynchronous framework with WSGI support.
 * [gevent](http://www.gevent.org/) - A coroutine-based Python networking library that uses [greenlet](https://github.com/python-greenlet/greenlet).
+* [aiochan](https://github.com/zh217/aiochan) - CSP-style concurrency with channels, select and multiprocessing.
 * [SCOOP](https://github.com/soravux/scoop) - Scalable Concurrent Operations in Python.
 * [Tomorrow](https://github.com/madisonmay/Tomorrow) - Magic decorator syntax for asynchronous code.
 * [uvloop](https://github.com/MagicStack/uvloop) - Ultra fast implementation of asyncio event loop on top of libuv.


### PR DESCRIPTION
## What is this Python project?

[aiochan](https://github.com/zh217/aiochan) is a concurrency library that is used on top of the built-in library [asyncio](https://docs.python.org/3/library/asyncio.html). It provides channels together with `put`, `get` and `select` operations on them as its concurrency primitives, thus enabling CSP-style concurrency programs to be written (like in Go or in Clojure's core.async). In additions to lots of convenient methods and functions which enable easy-to-read and easy-to-write concurrent dataflow, there are also methods provided that can overcome python's GIL restriction in order to fully utilise all CPU cores on a single machine.

## What's the difference between this Python project and similar ones?

None of the libraries already listed is similar to this one. Compared to those that are not listed (such as [python-csp](https://github.com/futurecore/python-csp), [aiochannel](https://github.com/tbug/aiochannel) and [aiostream](https://github.com/vxgmichel/aiostream)), they do not enable the full CSP-style programming (usually they do not provide `select`, which must be implemented inside the channel), or they are not actively maintained at all and do not work well with the newest python versions.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
