### PR TITLE
Add RESTful API / flask-rest-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,6 +954,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [flask-api](http://www.flaskapi.org/) - Browsable Web APIs for Flask.
     * [flask-restful](https://github.com/flask-restful/flask-restful) - Quickly building REST APIs for Flask.
     * [flask-restless](https://github.com/jfinkels/flask-restless) - Generating RESTful APIs for database models defined with SQLAlchemy.
+    * [flask-rest-api](https://github.com/Nobatek/flask-rest-api/) - DB agnostic framework to build auto-documented REST APIs with Flask and marshmallow.
 * Pyramid
     * [cornice](https://github.com/Cornices/cornice) - A RESTful framework for Pyramid.
 * Framework agnostic


### PR DESCRIPTION
Repo: https://github.com/Nobatek/flask-rest-api/
Docs: https://flask-rest-api.readthedocs.io

## What is this Python project?

DB agnostic framework to build auto-documented REST APIs with Flask and marshmallow

## What's the difference between this Python project and similar ones?

This is a glue layer on top of great libraries from the marshmallow ecosystem:

- marshmallow itself for serialization, deserialization and validation
- webargs to parse request arguments
- apispec to generate OpenAPI documentation

flask-rest-api does not develop its own serialization/deserialization logic, which means less potential errors. It relies on marshmallow, which is a reference library for those tasks. It reduces the boilerplate even more if the application uses an ORM or ODM that can generate marshmallow schemas from the database model (marshmallow-sqlalchemy, umongo or marshmallow-mongoengine,...).

The OpenAPI (Swagger) specification is automatically generated, yet customizable, and exposed with ReDoc or Swagger UI.

It includes features not found in other similar frameworks:

- Pagination
- ETag

flask-rest-api is Python3 only. It supports marshmallow 2 and 3.


--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.