### PR TITLE
Add Uplink to HTTP Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [httplib2](https://github.com/httplib2/httplib2) - Comprehensive HTTP client library.
 * [requests](http://docs.python-requests.org/en/latest/) - HTTP Requests for Humans™.
 * [treq](https://github.com/twisted/treq) - Python requests like API built on top of Twisted's HTTP client.
+* [uplink](https://github.com/prkumar/uplink) - Builds reusable objects for consuming HTTP APIs with decorators and function annotations.
 * [urllib3](https://github.com/shazow/urllib3) - A HTTP library with thread-safe connection pooling, file post support, sanity friendly.
 
 ## Hardware


### PR DESCRIPTION
## What is this Python project?

[Uplink](https://github.com/prkumar/uplink) turns your HTTP API into a Python class.
```python
from uplink import Consumer, get, headers, Path, Query

class GitHub(Consumer):
    """A Python Client for the GitHub API."""

    @get("users/{user}/repos")
    def get_repos(self, user: Path, sort_by: Query("sort")):
        """Retrieves the user's public repositories."""
```

Uplink is a **Declarative** HTTP Client for Python:

- Builds Reusable Objects for Consuming Web APIs.
- Works with **Requests**, **asyncio**, and **Twisted**.
- Inspired by [Retrofit](http://square.github.io/retrofit/)


## What's the difference between this Python project and similar ones?

- Quickly Define Structured API Clients
- Bring Your Own HTTP Library
- Easy and Transparent Deserialization/Serialization
- Extendable
- Authentication

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
