### PR TITLE
PyYAML-tags library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1049,6 +1049,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [Python-Markdown](https://github.com/waylan/Python-Markdown) - A Python implementation of John Gruber’s Markdown.
 * YAML
     * [PyYAML](http://pyyaml.org/) - YAML implementations for Python.
+    * [PyYAML-tags](https://github.com/meiblorn/pyyaml-tags) — Custom tags for the [PyYAML](http://pyyaml.org/) library
 * CSV
     * [csvkit](https://github.com/wireservice/csvkit) - Utilities for converting to and working with CSV.
 * Archive


### PR DESCRIPTION
## What is this Python project?

PyYAML-Tags: [GitHub](https://github.com/meiblorn/pyyaml-tags), [PyPI](https://pypi.org/project/pyyaml-tags/)

- Custom tags support for the mature PyYAML library
- Simple API
- Extensible 

## What's the difference between this Python project and similar ones?

- There is no alternatives with such functionality for the Python YAML processing.
- Good documentation
- MIT Licence

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
