### PR TITLE
Add pytest-cov plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1115,6 +1115,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [model_mommy](https://github.com/vandersonmota/model_mommy) - Creating random fixtures for testing in Django.
 * Code Coverage
     * [coverage](https://pypi.python.org/pypi/coverage) - Code coverage measurement.
+    * [pytest-cov](https://github.com/pytest-dev/pytest-cov) - Code coverage measurement and reports.
 * Fake Data
     * [mimesis](https://github.com/lk-geimfari/mimesis) - is a Python library that help you generate fake data.
     * [fake2db](https://github.com/emirozer/fake2db) - Fake database generator.


### PR DESCRIPTION
## What is this Python project?

This is a Python plugin to measure and generate reports of code coverage.
It is very simple to use, is MIT licensed and is compatible with coverage package.

## What's the difference between this Python project and similar ones?

Compared to coverage the `pytest-cov` plugin does some extras:

- Subprocess support: you can fork or run stuff in a subprocess and will get covered without any fuss.
- Xdist support: you can use all of pytest-xdist's features and still get coverage.
- Consistent pytest behavior. If you run coverage run -m pytest you will have slightly different sys.path (CWD will be in it, unlike when running pytest).

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
