### PR TITLE
Add kubernetes client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [psutil](https://github.com/giampaolo/psutil) - A cross-platform process and system utilities module.
 * [SaltStack](https://github.com/saltstack/salt) - Infrastructure automation and management system.
 * [supervisor](https://github.com/Supervisor/supervisor) - Supervisor process control system for UNIX.
+* [kubernetes-client](https://github.com/kubernetes-client/python) - Official Python client library for kubernetes.
 
 ## Distribution
 


### PR DESCRIPTION
## What is this Python project?

Official Python client library for the kubernetes API.
It provides an easy way to manage (create, delete, update) kubernetes deploys.

## What's the difference between this Python project and similar ones?

I haven't found a similar library for Python yet.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
