### PR TITLE
Add betamax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1109,6 +1109,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [Mocket](https://github.com/mindflayer/python-mocket) - Socket Mock Framework plus HTTP[S]/asyncio/gevent mocking library with recording/replaying capability.
     * [responses](https://github.com/getsentry/responses) - A utility library for mocking out the requests Python library.
     * [VCR.py](https://github.com/kevin1024/vcrpy) - Record and replay HTTP interactions on your tests.
+    * [betamax](https://github.com/betamaxpy/betamax) - A VCR imitation for requests.
 * Object Factories
     * [factory_boy](https://github.com/FactoryBoy/factory_boy) - A test fixtures replacement for Python.
     * [mixer](https://github.com/klen/mixer) - Another fixtures replacement. Supported Django, Flask, SQLAlchemy, Peewee and etc.


### PR DESCRIPTION
## What is this Python project?

Betamax is a VCR imitation for requests. This will make mocking out requests much easier.

Betamax intercepts every request you make and attempts to find a matching request that has already been intercepted and recorded.

> Betamax records your HTTP interactions so the NSA does not have to.

## What's the difference between this Python project and similar ones?

- It is super easy to use.
- It works very well with [requests](http://docs.python-requests.org/en/master/).
- It stores cassettes in JSON format. 💪 
- It is open source. ❤️ 

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
