### PR TITLE
Add a python library to extract data from pdf invoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
     * [howdoi](https://github.com/gleitz/howdoi) - Instant coding answers via the command line.
     * [httpie](https://github.com/jakubroztocil/httpie) - A command line HTTP client, a user-friendly cURL replacement.
+    * [invoice2data](https://github.com/invoice-x/invoice2data) - A modular Python library to extract data from PDF invoices
     * [kube-shell](https://github.com/cloudnativelabs/kube-shell) - An integrated shell for working with the Kubernetes CLI.
     * [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.
     * [PathPicker](https://github.com/facebook/PathPicker) - Select files out of bash output.


### PR DESCRIPTION
Added invoice2data (A modular Python library to extract data from PDF invoices)

## What is this Python project?
A modular Python library to support your accounting process.
 - extracts text from PDF files using different techniques, like pdftotext, pdfminer or tesseract OCR.
 - searches for regex in the result using a YAML-based template system
 - saves results as CSV, JSON or XML or renames PDF files to match the content.

## What's the difference between this Python project and similar ones?
I haven't come across any such project in python

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
