### PR TITLE
Add plotnine

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [bqplot](https://github.com/bloomberg/bqplot) - Interactive Plotting Library for the Jupyter Notebook
 * [ggplot](https://github.com/yhat/ggpy) - Same API as ggplot2 for R.
 * [Matplotlib](http://matplotlib.org/) - A Python 2D plotting library.
+* [plotnine](https://github.com/has2k1/plotnine) - An implementation of a grammar of graphics based on ggplot2.
 * [Pygal](http://www.pygal.org/en/latest/) - A Python SVG Charts Creator.
 * [PyGraphviz](https://pypi.python.org/pypi/pygraphviz) - Python interface to [Graphviz](http://www.graphviz.org/).
 * [PyQtGraph](http://www.pyqtgraph.org/) - Interactive and realtime 2D/3D/Image plotting and science/engineering widgets.


### PR DESCRIPTION
## What is this Python project?

plotnine is an implementation of a grammar of graphics in Python, it is based on ggplot2. 

## What's the difference between this Python project and similar ones?

It is similar to `ggplot` but `ggplot` is no longer maintained. The last commit on that repo was 2 years ago. https://github.com/yhat/ggpy/issues/654.

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
