### PR TITLE
Add Ray to Cluster computing

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [faust](https://github.com/robinhood/faust) - A stream processing library, porting the ideas from [Kafka Streams](https://kafka.apache.org/documentation/streams/) to Python.
 * [luigi](https://github.com/spotify/luigi) - A module that helps you build complex pipelines of batch jobs.
 * [mrjob](https://github.com/Yelp/mrjob) - Run MapReduce jobs on Hadoop or Amazon Web Services.
+* [Ray](https://github.com/ray-project/ray/) - A system for parallel and distributed Python that unifies the machine learning ecosystem.
 * [streamparse](https://github.com/Parsely/streamparse) - Run Python code against real-time streams of data via [Apache Storm](http://storm.apache.org/).
 
 ## Code Analysis


### PR DESCRIPTION
## What is this Python project?

Ray is a flexible, high-performance distributed execution framework.

 - Achieves parallelism in Python with simple and consistent API.
 - Particularly suited for machine learning (agnostic to the machine learning library of choice)
 - Forms the base of Ray's own distributed libraries for deep and reinforcement learning, processing of Pandas dataframes, and hyper parameter search.
 - Uses Plasma as its object store which allows to efficiently share large numpy arrays (or objects serializable with Apache Arrow) between the processes, avoiding unnecessary data copies and with only minimal deserialization

## What's the difference between this Python project and similar ones?

 - Less overhead and lower latency with bottom up scheduling than similar projects
 - Actors - allow sharing mutable state between tasks
 - Similar to Dask, for more details see a comparison here:  https://github.com/ray-project/ray/issues/642

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
