### PR TITLE
Added Boto3 for Sending Email in Email Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [modoboa](https://github.com/modoboa/modoboa) - A mail hosting and management platform including a modern and simplified Web UI.
 * [Nylas Sync Engine](https://github.com/nylas/sync-engine) - Providing a RESTful API on top of a powerful email sync platform.
 * [yagmail](https://github.com/kootenpv/yagmail) - Yet another Gmail/SMTP client.
+* [boto3](https://github.com/boto/boto3) - Send email using AWS SES
 
 ## Environment Management
 


### PR DESCRIPTION
Boto3 could be used to send Emails using AWS SES

## What is this Python project?
Boto3 is complete library which could be used to consume AWS APIs in Python. This could be used to consume AWS SES API as well which can be used to send transnational or promotional emails.

Describe features.
This is the only most widely used library for consuming AWS features in Python.

## What's the difference between this Python project and similar ones?
No other project is there.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
