### PR TITLE
Add Cloudsmith (a PyPi-compatible service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,6 +903,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [bandersnatch](https://bitbucket.org/pypa/bandersnatch) - PyPI mirroring tool provided by Python Packaging Authority (PyPA).
 * [devpi](http://doc.devpi.net/latest/) - PyPI server and packaging/testing/release tool.
 * [localshop](https://github.com/jazzband/localshop) - Local PyPI server (custom packages and auto-mirroring of pypi).
+* [Cloudsmith](https://cloudsmith.io) - A fully managed package management SaaS with support for Python packages (and many others).
 
 ## Permissions
 


### PR DESCRIPTION
## What is this Python project?

This PR adds a link to [Cloudsmith](https://cloudsmith.io), which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has first-class support for Python package repositories (and many other package formats, such as Python/Npm), plus org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc.

## What's the difference between this Python project and similar ones?

It's similar to [PyPi Warehouse](https://pypi.org), but is a universal packagement service that supports many different technologies beyond just Python package hosting (so would be useful for polygot setups, such as combining with Npm). Cloudsmith has a focus on simplicity and an ethos for being as secure as possible by default, which is seen in the breadth of features offered (e.g. automatic GPG signing, entitlements control, geo/IP control, etc.)

*Full disclosure:* I work at Cloudsmith.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
