### PR TITLE
Add roslibpy to robotics

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,6 +972,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [PythonRobotics](https://github.com/AtsushiSakai/PythonRobotics) - This is a compilation of various robotics algorithms with visualizations.
 * [rospy](http://wiki.ros.org/rospy) - This is a library for ROS (Robot Operating System).
+* [roslibpy](https://github.com/gramaziokohler/roslibpy/) - ROS Bridge client library allows to create and talk to ROS nodes from Python & IronPython.
 
 ## RPC Servers
 


### PR DESCRIPTION
## What is this Python project?

Python ROS Bridge library allows to use Python and IronPython to interact with ROS, the open-source robotic middleware. It uses WebSockets to connect to [rosbridge 2.0 ](http://wiki.ros.org/rosbridge_suite)and provides publishing, subscribing, service calls, actionlib, TF, and other essential ROS functionality.

Unlike the **rospy** library, this does not require a local ROS environment, allowing usage from platforms other than Linux.

## What's the difference between this Python project and similar ones?

- This is the only Python client for ROS that is cross platforms
- Supports IronPython as well (which means it runs inside Rhino/Grasshopper for 3D/architecture applications)
- The closest package to this would be *rospy*, but it only runs in Linux, and only within a ROS environment

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
