### PR TITLE
Add asyncpg - async PostgreSQL client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [oursql](https://pythonhosted.org/oursql/) - A better MySQL connector with support for native prepared statements and BLOBs.
     * [PyMySQL](https://github.com/PyMySQL/PyMySQL) - A pure Python MySQL driver compatible to mysql-python.
 * PostgreSQL - [awesome-postgres](https://github.com/dhamaniasad/awesome-postgres)
+    * [asyncpg](https://github.com/MagicStack/asyncpg) A fast asyncio PostgreSQL client library.
     * [psycopg2](http://initd.org/psycopg/) - The most popular PostgreSQL adapter for Python.
     * [queries](https://github.com/gmr/queries) - A wrapper of the psycopg2 library for interacting with PostgreSQL.
     * [txpostgres](https://github.com/wulczer/txpostgres) - Twisted based asynchronous driver for PostgreSQL.


### PR DESCRIPTION
## What is this Python project?

[Asyncpg](https://github.com/MagicStack/asyncpg) is a fast async client library for PostgreSQL.

## What's the difference between this Python project and similar ones?
 - built for asyncio and Python 3.5+ async / await
 - plays well with the asyncio ecosystem e.g. with [Sanic](https://github.com/huge-success/sanic) or [Gino ORM](https://github.com/fantix/gino)
 - implements PostgreSQL server protocol natively and exposes its features directly
 - written almost entirely in Cython
 - [based on creators' benchmarks](https://github.com/magicstack/pgbench)
   - faster than alternatives 
   - can be approximately 3x faster than alternative Python libraries such as psycopg2 or aiopg
   - achieved query throughput [1M rows/s](https://magic.io/blog/asyncpg-1m-rows-from-postgres-to-python/)
   - significantly lower latency


--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
