### PR TITLE
Fix broken URL for ConfigObj library

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for storing and parsing configuration options.*
 
 * [config](https://www.red-dove.com/config-doc/) - Hierarchical config from the author of [logging](https://docs.python.org/3/library/logging.html).
-* [ConfigObj](http://www.voidspace.org.uk/python/configobj.html) - INI file parser with validation.
+* [ConfigObj](https://github.com/DiffSK/configobj) - INI file parser with validation.
 * [ConfigParser](https://docs.python.org/3/library/configparser.html) - (Python standard library) INI file parser.
 * [profig](http://profig.readthedocs.org/en/default/) - Config from multiple formats with value conversion.
 * [python-decouple](https://github.com/henriquebastos/python-decouple) - Strict separation of settings from code.


### PR DESCRIPTION
New URL is to Python 3 compatible port of the original library, blessed by original creator