### PR TITLE
Add Loguru (logging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Eliot](https://github.com/ScatterHQ/eliot) - Logging for complex & distributed systems.
 * [logbook](http://logbook.readthedocs.io/en/stable/) - Logging replacement for Python.
 * [logging](https://docs.python.org/3/library/logging.html) - (Python standard library) Logging facility for Python.
+* [loguru](https://github.com/Delgan/loguru) - Python logging made (stupidly) simple
 * [raven](https://github.com/getsentry/raven-python) - Python client for Sentry, a log/error tracking, crash reporting and aggregation platform for web applications.
 
 ## Machine Learning


### PR DESCRIPTION
## What is this Python project?

Very nice and dead simple logging library.

## What's the difference between this Python project and similar ones?

Compared to [Structlog](http://www.structlog.org/en/stable/), [Logbook](https://logbook.readthedocs.io/en/stable/), [Eliot](https://pypi.org/project/eliot/) and most of the other available third-party logging library in the Python ecosystem, Loguru is extremely simple to use and understand, while still offering a wide range of option and capabilities.

It is also two-way compatible with the standard library logging package.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
