### PR TITLE
Added PRAW to "Third Party API" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1177,6 +1177,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [gmail](https://github.com/charlierguo/gmail) - A Pythonic interface for Gmail.
 * [google-api-python-client](https://github.com/google/google-api-python-client) - Google APIs Client Library for Python.
 * [gspread](https://github.com/burnash/gspread) - Google Spreadsheets Python API.
+* [praw](https://github.com/praw-dev/praw) - "Python Reddit API Wrapper" for simple access to the Reddit API
 * [twython](https://github.com/ryanmcgrath/twython) - A Python wrapper for the Twitter API.
 
 ## URL Manipulation


### PR DESCRIPTION
## What is this Python project?

PRAW is the "Python Reddit API Wrapper". It's used for simple API access to the Reddit API.

## What's the difference between this Python project and similar ones?

PRAW is a Python library used specifically to access the Reddit API and should fit perfectly with the other "Third Party API's" in this repo.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
