### PR TITLE
Adds DJ-Models (Pluggable Django ORM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,6 +867,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries that implement Object-Relational Mapping or data mapping techniques.*
 
 * Relational Databases
+    * [Dj-Models](https://github.com/iMerica/dj-models) - Use Django' ORM in any Python web framework (e.g Flask + Django Models).
     * [Django Models](https://docs.djangoproject.com/en/dev/topics/db/models/) - A part of Django.
     * [SQLAlchemy](http://www.sqlalchemy.org/) - The Python SQL Toolkit and Object Relational Mapper.
         * [awesome-sqlalchemy](https://github.com/dahlia/awesome-sqlalchemy)

--- a/README.md
+++ b/README.md
@@ -867,7 +867,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries that implement Object-Relational Mapping or data mapping techniques.*
 
 * Relational Databases
-    * [Dj-Models](https://github.com/iMerica/dj-models) - Use Django' ORM in any Python web framework (e.g Flask + Django Models).
+    * [Dj-Models](https://github.com/iMerica/dj-models) - Use Django's ORM in any Python web framework (e.g Flask + Django Models).
     * [Django Models](https://docs.djangoproject.com/en/dev/topics/db/models/) - A part of Django.
     * [SQLAlchemy](http://www.sqlalchemy.org/) - The Python SQL Toolkit and Object Relational Mapper.
         * [awesome-sqlalchemy](https://github.com/dahlia/awesome-sqlalchemy)


### PR DESCRIPTION
## What is this Python project?

This project allows Python developers to use Django's ORM and declarative models in any synchronous Python web framework. I've published it to PyPI [here](https://pypi.org/project/DJModels/).

## What's the difference between this Python project and similar ones?

I'm not aware of another effort to excise Django's Models from the entire framework so that it can be used in a pluggable manner (similar to how Active Record can easily be used with Sinatra). 

That said, DJ-Models definitely competes with SQLAlchemy. Anywhere you would begrudgingly choose Flask/Pyramid + SQLAlchemy, you can now choose Flask/Pyramid + DJ-Models.


Here's a [demo app](https://github.com/iMerica/dj-models-demo) using Flask + Dj-Models. 
