### PR TITLE
Adding cattrs serializer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for serializing complex data types*
 
 * [marshmallow](https://github.com/marshmallow-code/marshmallow) - marshmallow is an ORM/ODM/framework-agnostic library for converting complex datatypes, such as objects, to and from native Python datatypes.
+* [cattrs](https://github.com/Tinche/cattrs) - Complex custom class converters for [attrs](https://github.com/hynek/attrs). It serializes-deserializes nested objects (not only attrs) to and from `dict` or `tuple`.
 
 ## Serverless Frameworks
 


### PR DESCRIPTION
## What is this Python project?

* Serialization nested `attrs` objects to and from `dict` or `tuple`.

## What's the difference between this Python project and similar ones?

* Automatically detects best class to deserialize to among `Union[...]` of types from a type annotation.
--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.