### PR TITLE
Adds Arrow to Date and Time section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for working with dates and times.*
 
+* [Arrow](https://github.com/crsmithdev/arrow) - Better dates & times for Python.
 * [Chronyk](https://github.com/KoffeinFlummi/Chronyk) - A Python 3 library for parsing human-written times and dates.
 * [dateutil](https://github.com/dateutil/dateutil) - Extensions to the standard Python [datetime](https://docs.python.org/3/library/datetime.html) module.
 * [delorean](https://github.com/myusuf3/delorean/) - A library for clearing up the inconvenient truths that arise dealing with datetimes.


### PR DESCRIPTION
## What is this Python project?

Arrow is a mature drop-in replacement for `datetime` that brings sanity to the timezone madness that comes by default.

## What's the difference between this Python project and similar ones?

Arrow and Maya are somewhat similar, with Maya being more oriented towards natural language parsing and generation, and Arrow more geared to be a fast and feature complete drop-in replacement. Says [Kenneth](https://www.kennethreitz.org/essays/introducing-maya-datetimes-for-humans#yui_3_17_2_1_1550687348228_225):

> Arrow, for example, is a fantastic library, but isn't what I wanted in a datetime library. In many ways, it's better than Maya for certian [sic] things. In some ways, in my opinion, it's not.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
