### PR TITLE
Added RESTPie3 REST API Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,6 +960,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [flask-api](http://www.flaskapi.org/) - Browsable Web APIs for Flask.
     * [flask-restful](https://github.com/flask-restful/flask-restful) - Quickly building REST APIs for Flask.
     * [flask-restless](https://github.com/jfinkels/flask-restless) - Generating RESTful APIs for database models defined with SQLAlchemy.
+    * [RESTPie3](https://github.com/tomimick/restpie3) - REST API server starter kit based on Flask, uWSGI, PostgreSQL - core features in a clean package
 * Pyramid
     * [cornice](https://github.com/Cornices/cornice) - A RESTful framework for Pyramid.
 * Framework agnostic


### PR DESCRIPTION
RESTPie3 is a REST API starter kit that helps you quickly build a robust REST server. The kit contains all the essential features that are usually needed in a server. Clean, readable codebase.

I have used this foundation in several production projects over the years so it is quite mature code.

Features from the doc:

* Simple and flexible server with minimum dependencies
* Process-based request workers, not thread-based nor async
* Secure server-side sessions with Redis storage
* Robust worker management: restarts, timecapping, max life
* Background tasks
* Built-in cron
* Automatic directory page listing the API methods and their docstrings
* Redis as a generic storage with expiring keys, lightweight queues
* Email & password authentication with secure algorithms
* User role model and authorization of API methods via simple decorator
* Logging system with practical data for troubleshooting, detects slow
  requests, warnings&errors colorized
* Server reload on code change
* Database migrations
* Docker image for the "big cloud"
* Fast rsync deployment of updates to servers
* Tests for the API

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
