### PR TITLE
Add the Square payments SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [forex-python](https://github.com/MicroPyramid/forex-python) - Foreign exchange rates, Bitcoin price index and currency conversion.
 * [saleor](http://getsaleor.com/) - An e-commerce storefront for Django.
 * [shoop](https://www.shuup.com/en/) - An open source E-Commerce platform based on Django.
+* [Square](https://github.com/square/connect-python-sdk) - The official SDK for Square payments and APIs.
 
 ## Editor Plugins and IDEs
 


### PR DESCRIPTION
## What is this Python project?

This is the official SDK for Square APIs.

## What's the difference between this Python project and similar ones?

It lets you take payments online with Square, which a lot of business want because there are millions of Square in-person sellers.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
