### PR TITLE
Add jsons to serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for serializing complex data types*
 
 * [marshmallow](https://github.com/marshmallow-code/marshmallow) - marshmallow is an ORM/ODM/framework-agnostic library for converting complex datatypes, such as objects, to and from native Python datatypes.
+* [jsons](https://github.com/ramonhagenaars/jsons) - jsons is a lightweight library for (de)serializing pure Python objects to and from JSON, with no magic or special requirements.
 
 ## Serverless Frameworks
 


### PR DESCRIPTION
## What is this Python project?

Jsons (Json Serialization) is an easy to use Python library for converting Plain Old Python Objects to JSON and back.

* Just Python, no compromising your models
* Human readable JSON without meta pollution
* Easily extendable and customizable
* Easy to use

## What's the difference between this Python project and similar ones?

* Jsons does not enforce inheritance for your models, like Marshmellow does
* Jsons can serialize and deserialize objects to JSON in much fewer lines of code than the standard `json`

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
