### PR TITLE
Add 'tartiflette', 'tartiflette-aiohttp' and 'tartiflette-asgi' for Python 3.6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ Code Formatters
 *Libraries for working with GraphQL.*
 
 * [tartiflette](https://tartiflette.io) - SDL-first GraphQL engine implementation for Python 3.6+ and asyncio.
-* [tartiflette-aiohttp](https://github.com/tartiflette/tartiflette-aiohttp/) - Wrapper of tartiflette to expose GraphQL API over HTTP based on aiohttp / 3.6+ / asyncio.
+* [tartiflette-aiohttp](https://github.com/tartiflette/tartiflette-aiohttp/) - An `aiohttp`-based wrapper for Tartiflette to expose GraphQL APIs over HTTP.
 * [tartiflette-asgi](https://github.com/tartiflette/tartiflette-asgi/) - ASGI support for the Tartiflette GraphQL engine.
 
 ## Game Development

--- a/README.md
+++ b/README.md
@@ -609,6 +609,14 @@ Code Formatters
 * [urwid](http://urwid.org/) - A library for creating terminal GUI applications with strong support for widgets, events, rich colors, etc.
 * [wxPython](https://wxpython.org/) - A blending of the wxWidgets C++ class library with the Python.
 
+## GraphQL
+
+*Libraries for working with GraphQL.*
+
+* [tartiflette](https://tartiflette.io) - GraphQL Implementation, SDL First, for python 3.6+ / asyncio.
+* [tartiflette-aiohttp](https://github.com/tartiflette/tartiflette-aiohttp/) - Wrapper of tartiflette to expose GraphQL API over HTTP based on aiohttp / 3.6+ / asyncio.
+* [tartiflette-asgi](https://github.com/tartiflette/tartiflette-asgi/) - a wrapper that provides ASGI support for the Tartiflette Python GraphQL engine.
+
 ## Game Development
 
 *Awesome game development libraries.*

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ Code Formatters
 
 *Libraries for working with GraphQL.*
 
-* [tartiflette](https://tartiflette.io) - GraphQL Implementation, SDL First, for python 3.6+ / asyncio.
+* [tartiflette](https://tartiflette.io) - SDL-first GraphQL engine implementation for Python 3.6+ and asyncio.
 * [tartiflette-aiohttp](https://github.com/tartiflette/tartiflette-aiohttp/) - Wrapper of tartiflette to expose GraphQL API over HTTP based on aiohttp / 3.6+ / asyncio.
 * [tartiflette-asgi](https://github.com/tartiflette/tartiflette-asgi/) - a wrapper that provides ASGI support for the Tartiflette Python GraphQL engine.
 

--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ Code Formatters
 
 * [tartiflette](https://tartiflette.io) - SDL-first GraphQL engine implementation for Python 3.6+ and asyncio.
 * [tartiflette-aiohttp](https://github.com/tartiflette/tartiflette-aiohttp/) - Wrapper of tartiflette to expose GraphQL API over HTTP based on aiohttp / 3.6+ / asyncio.
-* [tartiflette-asgi](https://github.com/tartiflette/tartiflette-asgi/) - a wrapper that provides ASGI support for the Tartiflette Python GraphQL engine.
+* [tartiflette-asgi](https://github.com/tartiflette/tartiflette-asgi/) - ASGI support for the Tartiflette GraphQL engine.
 
 ## Game Development
 


### PR DESCRIPTION
## What is this Python project?

* **Tartiflette** is a Python implementation of GraphQL, **SDL First**.
* 100% **Open Source** from day one.
* Compatible only for Python 3.6+ / asyncio.

## What's the difference between this Python project and similar ones?

* This is not a port of GraphQL JS but a brand new implementation built with the Zen of Python in mind.
* Create GraphQL schema **only** with the SDL _(Schema Definition Language)_.
* Build only for python 3.6+ and asyncio.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
