### PR TITLE
Added RESTEasyCLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Code Formatters
     * [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.
     * [pgcli](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting.
     * [saws](https://github.com/donnemartin/saws) - A Supercharged [aws-cli](https://github.com/aws/aws-cli).
+    * [RESTEasyCLI](https://github.com/rapidstack/RESTEasyCLI) - A Handy REST API client.
 
 ## Compatibility
 


### PR DESCRIPTION
## What is this Python project?

Handy REST API client on your terminal.

## What's the difference between this Python project and similar ones?

Most similar projects I could find are httpie, curl etc. Unlike these "general purpose HTTP clients", this library dedicates itself to REST API and aims to bring the most useful features of popular GUI based REST clients on your terminal.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
