### PR TITLE
Add wikilink in Web Content Extracting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1175,6 +1175,7 @@ Code Formatters
 * [sumy](https://github.com/miso-belica/sumy) - A module for automatic summarization of text documents and HTML pages.
 * [textract](https://github.com/deanmalmgren/textract) - Extract text from any document, Word, PowerPoint, PDFs, etc.
 * [toapi](https://github.com/gaojiuli/toapi) - Every web site provides APIs.
+* [wikilink](https://github.com/tranlyvu/wiki-link) - A web-scraping application to find the minimum number of links between 2 given wiki pages.
 
 ## Web Crawling & Web Scraping
 


### PR DESCRIPTION
## What is this Python project?

A web-scraping application to find the minimum number of links between 2 given wiki pages

## What's the difference between this Python project and similar ones?

There is no similar project

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
