### PR TITLE
add datedelta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Python [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+﻿# Awesome Python [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 A curated list of awesome Python frameworks, libraries, software and resources.
 
@@ -388,6 +388,7 @@ Code Formatters
 * [pytz](https://launchpad.net/pytz) - World timezone definitions, modern and historical. Brings the [tz database](https://en.wikipedia.org/wiki/Tz_database) into Python.
 * [when.py](https://github.com/dirn/When.py) - Providing user-friendly functions to help perform common date and time actions.
 * [maya](https://github.com/kennethreitz/maya) - Datetimes for Humans, Maya is mostly built around the headaches and use-cases around parsing datetime data from websites.
+* [datedelta](https://github.com/aaugustin/datedelta) - It can add and substract years, months, or days to dates while accounting for oddities of the Gregorian calendar.
 
 ## Debugging Tools
 


### PR DESCRIPTION
## What is this Python project?
This project deals with simple arithmetic operations on date and time based on Gregorian calendar. 

Describe features.

## What's the difference between this Python project and similar ones?
There are two date arithmetic traps in the Gregorian calendar:
 (1)   Leap years. Problems arise when adding years to a February 29th gives a result in a non-leap year.
 (2)Variable number of days in months. Problems arise when adding months to a 29th, 30th or 31st gives a result in a month where that day doesn't exist.
In both cases, the result must be changed to the first day of the next month.

Enumerate comparisons.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
