### PR TITLE
Add async-sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ Code Formatters
 
 *Libraries for sending and parsing email.*
 
+* [async_sender](https://github.com/bruziev/async_sender) - Simple interface to set up SMTP and send asynchronously email messages.
 * [envelopes](http://tomekwojcik.github.io/envelopes/) - Mailing for human beings.
 * [flanker](https://github.com/mailgun/flanker) - A email address and Mime parsing library.
 * [imbox](https://github.com/martinrusev/imbox) - Python IMAP for Humans.


### PR DESCRIPTION
## What is this Python project?

AsyncSender provides a simple interface to set up a SMTP connection and send email messages asynchronously.

## What's the difference between this Python project and similar ones?

- Same interface [Flask-Mail](https://pythonhosted.org/Flask-Mail/)
- AsyncIO support

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
