### PR TITLE
Fix package repositories md link format

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,7 +857,7 @@ Code Formatters
 *Local PyPI repository server and proxies.*
 
 * [warehouse](https://github.com/pypa/warehouse) - Next generation Python Package Repository (PyPI).
-* [bandersnatch]https://github.com/pypa/bandersnatch/ - PyPI mirroring tool provided by Python Packaging Authority (PyPA).
+* [bandersnatch](https://github.com/pypa/bandersnatch/) - PyPI mirroring tool provided by Python Packaging Authority (PyPA).
 * [devpi](https://github.com/devpi/devpi) - PyPI server and packaging/testing/release tool.
 * [localshop](https://github.com/jazzband/localshop) - Local PyPI server (custom packages and auto-mirroring of pypi).
 


### PR DESCRIPTION
## What is this Python project?

Fixes syntax for existing project entry

## What's the difference between this Python project and similar ones?

No addition - only syntax fix

