### PR TITLE
Added django-bootstrap4 to Forms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ Code Formatters
 
 * [Deform](https://github.com/Pylons/deform) - Python HTML form generation library influenced by the formish form generation library.
 * [django-bootstrap3](https://github.com/dyve/django-bootstrap3) - Bootstrap 3 integration with Django.
+* [django-bootstrap4](https://github.com/zostera/django-bootstrap4) - Bootstrap 4 integration with Django.
 * [django-crispy-forms](https://github.com/django-crispy-forms/django-crispy-forms) - A Django app which lets you create beautiful forms in a very elegant and DRY way.
 * [django-remote-forms](https://github.com/WiserTogether/django-remote-forms) - A platform independent Django form serializer.
 * [WTForms](https://github.com/wtforms/wtforms) - A flexible forms validation and rendering library.


### PR DESCRIPTION
## What is this Python project?

django-bootstrap4 library : 
- The goal of this project is to seamlessly blend Django and Bootstrap 4.

## What's the difference between this Python project and similar ones?

- Support of bootstrap 4.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
