### PR TITLE
Adding the Atlas toolkit to the GUI section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ Code Formatters
 
 *Libraries for working with graphical user interface applications.*
 
+* [*Atlas* toolkit](https://q37.info/s/c7hfkzvs) - Lightweight and easy to use library to add a sharable web interface to programs.
 * [curses](https://docs.python.org/3/library/curses.html) - Built-in wrapper for [ncurses](http://www.gnu.org/software/ncurses/) used to create terminal GUI applications.
 * [Eel](https://github.com/ChrisKnott/Eel) - Little library for making simple Electron-like offline HTML/JS GUI apps, with full access to Python capabilities and libraries.
 * [enaml](https://github.com/nucleic/enaml) - Creating beautiful user-interfaces with Declaratic Syntax like QML.


### PR DESCRIPTION
## What is this Python project?

The [*Atlas* toolkit](http://q37.info/s/c7hfkzvs) is a fast and easy way to add a GUI (a web one) to a Python program. It only requires basic knowledge of HTML. It's **not** a web framework. The point is really to have a way as easy and fast as possible to add a GUI to programs, but, instead of the usual desktop interface, it will be a web interface.

Once launched, the program will automatically open a web browser displaying its interface. The program will also display the QR code corresponding to the URL opened by the web browser, so you can easily open this URL on your smartphone. No need to reconfigure the smartphone, or the router on which the computer running the program is connected, to use the program on it.

By simply sending the URL to someone, they can immediately use the program on their own smartphone or other device with a modern web browser connected to internet.

For electronic/robotic lovers, the *Atlas* toolkit can, without problem, be used on device such a [*Raspberry Pi Zero W*](https://q37.info/s/uthai3us), so you can write your own programs to pilot its *GPIO* from a smartphone.

## What's the difference between this Python project and similar ones?

The *Atlas* toolkit bears some similarities with web frameworks, but the *Atlas* toolkit :

* does not require the use of JavaScript,
* is very lightweight (less then 10 KB),
* does not require the development of a separate front-end (front-end and back-end are the same Python written program),
* have no dependencies on other packages,
* allows programs to be accessible from all over the internet without having to deploy them on a remote server.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
