### PR TITLE
adding parse_it

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Code Formatters
 
 *Libraries for storing and parsing configuration options.*
 
+* [parse_it](https://github.com/naorlivne/parse_it) - A python library for parsing multiple types of config files, envvars & command line argumants that takes the headache out of setting app configurations. 
 * [configobj](https://github.com/DiffSK/configobj) - INI file parser with validation.
 * [configparser](https://docs.python.org/3/library/configparser.html) - (Python standard library) INI file parser.
 * [profig](https://profig.readthedocs.io/en/default/) - Config from multiple formats with value conversion.


### PR DESCRIPTION
## What is this Python project?

parse_it is a python library for parsing multiple types of config files, envvars & command line arguments that takes the headache out of setting app configurations. 

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

-- supports TOML, YAML, JSON, INI, ENVVAR, CLI ARGS to allow enduser to pick how he prefers to configure the app without adding work to the dev.

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
