### PR TITLE
Added Cloudsmith (Python Repository)

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,12 +855,13 @@ Code Formatters
 
 ## Package Repositories
 
-*Local PyPI repository server and proxies.*
+*Local and hosted PyPI repository server and proxies.*
 
 * [warehouse](https://github.com/pypa/warehouse) - Next generation Python Package Repository (PyPI).
 * [bandersnatch](https://github.com/pypa/bandersnatch/) - PyPI mirroring tool provided by Python Packaging Authority (PyPA).
 * [devpi](https://github.com/devpi/devpi) - PyPI server and packaging/testing/release tool.
 * [localshop](https://github.com/jazzband/localshop) - Local PyPI server (custom packages and auto-mirroring of pypi).
+* [cloudsmith :heavy_dollar_sign:](https://cloudsmith.io/l/python-repository/) - A fully managed package management SaaS, with first-class support for public and private Python repositories (plus many others). Has a generous free-tier and is also completely free for open-source.
 
 ## Permissions
 


### PR DESCRIPTION
## What is this Python project?

Hi! This PR adds a link to [Cloudsmith](https://cloudsmith.io), which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has first-class support for Python (and many other package formats, such as Npm), plus org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc. Thank you. :-)

Full disclosure: I work at Cloudsmith. \o/

## What's the difference between this Python project and similar ones?

This is the first hosted repository to be listed, but obvious alternatives are PyPi itself. Cloudsmith provides private hosting and is usually used for internal development, distribution of vendored software, or when a secondary proxy to PyPi is required. It can also house many other types of assets.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
