### PR TITLE
Consider adding TemplateMail

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Code Formatters
 * [modoboa](https://github.com/modoboa/modoboa) - A mail hosting and management platform including a modern and simplified Web UI.
 * [Nylas Sync Engine](https://github.com/nylas/sync-engine) - Providing a RESTful API on top of a powerful email sync platform.
 * [yagmail](https://github.com/kootenpv/yagmail) - Yet another Gmail/SMTP client.
+* [TemplateMail](https://github.com/kkinder/templatemail) - Uses Jinja2 to send transactional, template-based emails with SMTP or Mailgun
 
 ## Environment Management
 


### PR DESCRIPTION
## What is this Python project?

I wrote TemplateMail as a simple solution to sending transactional emails in new projects. Since emails themselves are written in Jinja2, it brings separation between programming and copy editing concerns. It sends email using SMTP or Mailgun, but other backends are possible. Let me know if you have any questions and thanks for the consideration!

## What's the difference between this Python project and similar ones?

The most important distinction is that TemplateMail fully encloses all email content, including mail subjects, inside Jinja2 templates. This means that if you want to change the content or design of an email, you need to only edit the template, not the Python code.

By using Jinja2 templates and including Mailgun out of the box, TemplateMail covers the use cases for most new projects. I think it's pretty seful.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
