### PR TITLE
Add pyramid_openapi3 to list of Pyramid-based API frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,7 @@ Code Formatters
     * [flask-restless](https://github.com/jfinkels/flask-restless) - Generating RESTful APIs for database models defined with SQLAlchemy.
 * Pyramid
     * [cornice](https://github.com/Cornices/cornice) - A RESTful framework for Pyramid.
+    * [pyramid_openapi3](https://github.com/Pylons/pyramid_openapi3) - OpenAPI 3.0 integration for Pyramid.
 * Framework agnostic
     * [apistar](https://github.com/encode/apistar) - A smart Web API framework, designed for Python 3.
     * [falcon](http://falconframework.org/) - A high-performance framework for building cloud APIs and web app backends.


### PR DESCRIPTION
## What is this Python project?

pyramid_openapi3 is a Pyramid addon that allows you to validate Pyramid views against an OpenAPI 3.0 document. It also serves the Swagger UI for the OpenAPI document you provide. 

## What's the difference between this Python project and similar ones?

Compared to cornice, the main differentiator is that it is based on the fantastic OpenAPI 3.0 specification. 

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
