### PR TITLE
Add ezdxf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,7 +1014,9 @@ Code Formatters
 * CSV
     * [csvkit](https://github.com/wireservice/csvkit) - Utilities for converting to and working with CSV.
 * Archive
-    * [unp](https://github.com/mitsuhiko/unp) - A command line tool that can unpack archives easily.
+    * [unp](https://github.com/mitsuhiko/unp) - A command line tool that can unpack archives easily. 
+* DXF
+    * [ezdxf](https://github.com/mozman/ezdxf) - A Python package to create and modify DXF drawings, independent from the DXF version.
 
 ## Static Site Generator
 


### PR DESCRIPTION
A Python package to create and modify DXF drawings, independent from the DXF version. You can open/save every DXF file without losing any content (except comments), Unknown tags in the DXF file will be ignored but preserved for saving. With this behavior it is possible to open also DXF drawings that contains data from 3rd party applications.

[Quick-Info](https://github.com/mozman/ezdxf) 
----------

- ezdxf is a Python package to create new DXF files and read/modify/write existing DXF files
- the intended audience are developers
- requires at least CPython 3.5, for Python 2 support use ezdxf < 0.9
- OS independent
- additional required packages: [pyparsing](https://pypi.org/project/pyparsing/)
- MIT-License
- read/write/new support for DXF versions: R12, R2000, R2004, R2007, R2010, R2013 and R2018
- additional read support for DXF versions R13/R14 (upgraded to R2000)
- additional read support for older DXF versions than R12 (upgraded to R12)
- preserves third-party DXF content
- additional fast DXF R12 writer, that creates just an ENTITIES section with support for the basic DXF entities