### PR TITLE
Add maildown

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [imbox](https://github.com/martinrusev/imbox) - Python IMAP for Humans.
 * [inbox.py](https://github.com/kennethreitz/inbox.py) - Python SMTP Server for Humans.
 * [lamson](https://github.com/zedshaw/lamson) - Pythonic SMTP Application Server.
+* [maildown](https://github.com/chris104957/maildown) - Super simple email API with markdown support.
 * [Marrow Mailer](https://github.com/marrow/mailer) - High-performance extensible mail delivery framework.
 * [modoboa](https://github.com/modoboa/modoboa) - A mail hosting and management platform including a modern and simplified Web UI.
 * [Nylas Sync Engine](https://github.com/nylas/sync-engine) - Providing a RESTful API on top of a powerful email sync platform.


### PR DESCRIPTION
## What is this Python project?

Maildown is a super simple CLI/Python API for sending emails using Amazon SES. It is the easiest way of implementing transactional emails in any project 

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

- Far simpler to use than boto3
- Supports markdown and Jinja syntax out of the box
- Supports Css styling

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
