### PR TITLE
Add PySnooper

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [lptrace](https://github.com/khamidou/lptrace) - [strace](http://man7.org/linux/man-pages/man1/strace.1.html) for Python programs.
     * [manhole](https://github.com/ionelmc/python-manhole) - Debugging UNIX socket connections and present the stacktraces for all threads and an interactive prompt.
     * [pyringe](https://github.com/google/pyringe) - Debugger capable of attaching to and injecting code into Python processes.
+    * [pysnooper](https://github.com/cool-RR/PySnooper) - Print replacement traces functions with decorator.
     * [python-hunter](https://github.com/ionelmc/python-hunter) - A flexible code tracing toolkit.
 * Profiler
     * [line_profiler](https://github.com/rkern/line_profiler) - Line-by-line profiling.


### PR DESCRIPTION
## What is this Python project?

PySnooper is a replacement for debugging prints. Its function decorator automatically shows local variables and lines being executed.

## What's the difference between this Python project and similar ones?

I don't know similar projects.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
