### PR TITLE
Add FastAPI framework to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,6 +918,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [flask-restless](https://github.com/jfinkels/flask-restless) - Generating RESTful APIs for database models defined with SQLAlchemy.
 * Pyramid
     * [cornice](https://github.com/Cornices/cornice) - A RESTful framework for Pyramid.
+* Starlette
+    * [fastapi](https://github.com/tiangolo/fastapi) — A Python 3.6+ REST or GraphQL API framework with high performance, easy to learn, fast to code, automatic documented, ready for production.
 * Framework agnostic
     * [apistar](https://github.com/encode/apistar) - A smart Web API framework, designed for Python 3.
     * [falcon](http://falconframework.org/) - A high-performance framework for building cloud APIs and web app backends.


### PR DESCRIPTION
## What is this Python project?

[FastAPI](https://github.com/tiangolo/fastapi) is a modern, fast (high-performance), web framework for building APIs with Python 3.6+ based on standard Python type hints.

## What's the difference between this Python project and similar ones?

The key features are:

* Fast: Very high performance, on par with NodeJS and Go (thanks to Starlette and Pydantic). One of the fastest Python frameworks available.
* Fast to code: Increase the speed to develop features by about 200% to 300%.
* Fewer bugs: Reduce about 40% of human (developer) induced errors.
* Intuitive: Great editor support. Completion everywhere. Less time debugging.
* Easy: Designed to be easy to use and learn. Less time reading docs.
* Short: Minimize code duplication. Multiple features from each parameter declaration. Fewer bugs.
* Robust: Get production-ready code. With automatic interactive documentation.
* Standards-based: Based on (and fully compatible with) the open standards for APIs: OpenAPI (previously known as Swagger) and JSON Schema.

Independent TechEmpower benchmarks show FastAPI applications running under Uvicorn [as one of the fastest Python frameworks available](https://www.techempower.com/benchmarks/#section=test&runid=7464e520-0dc2-473d-bd34-dbdfd7e85911&hw=ph&test=query&l=zijzen-7), only below [Starlette](https://www.starlette.io/) and [Uvicorn](http://www.uvicorn.org/) themselves (used internally by FastAPI). To understand more about it, see the FastAPI section [Benchmarks](https://fastapi.tiangolo.com/benchmarks/).

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
