### PR TITLE
Add python-codicefiscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for administrative interfaces.*
 
 * [ajenti](https://github.com/ajenti/ajenti) - The admin panel your servers deserve.
+* [django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface) - Customizable responsive admin interface, based on a modern flat theme, it lets you customize the admin title, logo and colors by the admin itself. Popup windows replaced by modals.
 * [django-grappelli](https://grappelliproject.com/) - A jazzy skin for the Django Admin-Interface.
 * [django-jet](https://github.com/geex-arts/django-jet) - Modern responsive template for the Django admin interface with improved functionality.
 * [django-suit](https://djangosuit.com/) - Alternative Django Admin-Interface (free only for Non-commercial use).

--- a/README.md
+++ b/README.md
@@ -982,6 +982,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [marshmallow](https://github.com/marshmallow-code/marshmallow) - A lightweight library for converting complex objects to and from simple Python datatypes.
 * [pysimdjson](https://github.com/TkTech/pysimdjson) - A Python bindings for [simdjson](https://github.com/lemire/simdjson).
+* [python-codicefiscale](https://github.com/fabiocaccamo/python-codicefiscale) - A tiny library for encode/decode Italian fiscal codes - codifica/decodifica del Codice Fiscale.
 * [python-rapidjson](https://github.com/python-rapidjson/python-rapidjson) - A Python wrapper around [RapidJSON](https://github.com/Tencent/rapidjson).
 
 ## Serverless Frameworks


### PR DESCRIPTION
## What is this Python project?
[python-codicefiscale](https://github.com/fabiocaccamo/python-codicefiscale/) is a tiny library for encode/decode Italian fiscal code - codifica/decodifica del Codice Fiscale.

Features:
-  **Transliteration** for name/surname
-  **Multiple** birthdate formats (datetime/string) *(you can see all the supported string formats in* `tests/tests.py` *)*
-  **Automatic** birthplace city/foreign-country code detection from name
-  **Omocodia** support

## What's the difference between this Python project and similar ones?
- Datetimes auto-detected from strings
- City/country code autodetected from city/country name
- Well tested and updated

Enumerate comparisons.
- [pycodicefiscale](https://github.com/ema/pycodicefiscale) (not updated since 3 years)

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
