### PR TITLE
Add begins

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for building command-line applications.*
 
 * Command-line Application Development
+    * [begins](https://github.com/aliles/begins) - Command line programs for lazy humans.
     * [cement](http://builtoncement.com/) - CLI Application Framework for Python.
     * [click](http://click.pocoo.org/dev/) - A package for creating beautiful command line interfaces in a composable way.
     * [cliff](https://docs.openstack.org/developer/cliff/) - A framework for creating command-line programs with multi-level commands.


### PR DESCRIPTION
Begins makes command interface with help, logging, and subcommands dead simple.

## What is this Python project?

Command line programs for *lazy* humans.

* Decorate a function to be your programs starting point.
* Generate command line parser based on function signature.
* Search system environment for option default values.

Why begins?

I write a lot of small programs in `Python`_. These programs often accept a small number of simple command line arguments. Having to write command line parsing code in each of these small programs both breaks my train of thought and greatly increases the volume of code I am writing.

Begins was implemented to remove the boilerplate code from these Python programs. It's not intended to replace the rich command line processing needed for larger applications.

## What's the difference between this Python project and similar ones?

Simple and powerful.   Give it a try.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
