### PR TITLE
Added pdoc3 python documentation generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [awesome-sphinxdoc](https://github.com/yoloseem/awesome-sphinxdoc)
 * [pdoc](https://github.com/mitmproxy/pdoc) - Epydoc replacement to auto generate API documentation for Python libraries.
 * [pycco](https://github.com/pycco-docs/pycco) - The literate-programming-style documentation generator.
+* [pdoc3](https://github.com/pdoc3/pdoc) - Auto-generate API documentation for Python projects.
 
 ## Downloader
 


### PR DESCRIPTION
## What is this Python project?

```pdoc (pdoc3)```

## What's the difference between this Python project and similar ones?
An improved version of ```pdoc``` documentation generator.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
