### PR TITLE
Add django-admin-interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for administrative interfaces.*
 
 * [ajenti](https://github.com/ajenti/ajenti) - The admin panel your servers deserve.
+* [django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface) - Customizable responsive admin interface, based on a modern flat theme, it lets you customize the admin title, logo and colors by the admin itself. Popup windows replaced by modals.
 * [django-grappelli](https://grappelliproject.com/) - A jazzy skin for the Django Admin-Interface.
 * [django-jet](https://github.com/geex-arts/django-jet) - Modern responsive template for the Django admin interface with improved functionality.
 * [django-suit](https://djangosuit.com/) - Alternative Django Admin-Interface (free only for Non-commercial use).


### PR DESCRIPTION
## What is this Python project?
[django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface) is a customizable responsive admin interface, based on a modern flat theme, it lets you customize the admin title, logo and colors by the admin itself. Popup windows replaced by modals.

## Features
- Beautiful default **django-theme**
- Themes management and customization *(you can **customize admin title, logo and colors**)*
- Responsive
- List filter dropdown *(optional)*
- `NEW` **Related modal** *(instead of the old popup window, optional)*
- `NEW` **Environment name/marker**
- Compatibility / Style optimizations for:
  - `django-ckeditor`
  - `django-dynamic-raw-id`
  - `django-modeltranslation`
  - `django-tabbed-admin`
  - `sorl-thumbnail`

## What's the difference between this Python project and similar ones?
- It is based on the default django admin, templates are not overridden
- Any admin theme can be customized to fit client needs
- Multiple themes support
- Well tested and keep updated

### Enumerate comparisons
- Check comparisons on [django-packages](https://djangopackages.org/grids/g/admin-interface/)

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
