### PR TITLE
Add django-maintenance-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for scheduling jobs.*
 
 * [APScheduler](http://apscheduler.readthedocs.io/en/latest/) - A light but powerful in-process task scheduler that lets you schedule functions.
+* [django-maintenance-mode](https://github.com/fabiocaccamo/django-maintenance-mode) - django-maintenance-mode shows a 503 error page when maintenance mode is on.
 * [django-schedule](https://github.com/thauber/django-schedule) - A calendaring app for Django.
 * [doit](http://pydoit.org/) - A task runner and build tool.
 * [gunnery](https://github.com/gunnery/gunnery) - Multipurpose task execution tool for distributed systems with web-based interface.


### PR DESCRIPTION
## What is this Python project?
[django-maintenance-mode](https://github.com/fabiocaccamo/django-maintenance-mode) shows a 503 error page when maintenance mode is on.

## Features:
-  Customizable 503 page
-  Can exclude staff
-  Can redirect to another url
-  Can use a custom 503 template
-  Can exclude IP addresses
-  Can exclude superuser
-  Can ignore urls
-  Works at application level
-  Can be activated/deactivated using commands
-  Can be activated/deactivated using urls
-  Works at view level
-  Can work at view level
-  Pluggable backends support

## What's the difference between this Python project and similar ones?
-  Check comparisons on [django-packages](https://djangopackages.org/grids/g/maintenance-mode/)

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
