### PR TITLE
Add python-codicefiscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,6 +982,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [marshmallow](https://github.com/marshmallow-code/marshmallow) - A lightweight library for converting complex objects to and from simple Python datatypes.
 * [pysimdjson](https://github.com/TkTech/pysimdjson) - A Python bindings for [simdjson](https://github.com/lemire/simdjson).
+* [python-codicefiscale](https://github.com/fabiocaccamo/python-codicefiscale/) - A tiny library for encode/decode Italian fiscal code - codifica/decodifica del Codice Fiscale.
 * [python-rapidjson](https://github.com/python-rapidjson/python-rapidjson) - A Python wrapper around [RapidJSON](https://github.com/Tencent/rapidjson).
 
 ## Serverless Frameworks


### PR DESCRIPTION
## What is this Python project?
[python-codicefiscale](https://github.com/fabiocaccamo/python-codicefiscale/) is a tiny library for encode/decode Italian fiscal code - codifica/decodifica del Codice Fiscale.

Features:
-  **Transliteration** for name/surname
-  **Multiple** birthdate formats (datetime/string) *(you can see all the supported string formats in* `tests/tests.py` *)*
-  **Automatic** birthplace city/foreign-country code detection from name
-  **Omocodia** support

## What's the difference between this Python project and similar ones?
- Datetimes auto-detected from strings
- City/country code autodetected from city/country name
- Well tested and updated

Enumerate comparisons.
- [pycodicefiscale](https://github.com/ema/pycodicefiscale) (not updated since 3 years)

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
