### PR TITLE
Add PySnooper for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [django-devserver](https://github.com/dcramer/django-devserver) - A drop-in replacement for Django's runserver.
     * [flask-debugtoolbar](https://github.com/mgood/flask-debugtoolbar) - A port of the django-debug-toolbar to flask.
     * [pyelftools](https://github.com/eliben/pyelftools) - Parsing and analyzing ELF files and DWARF debugging information.
+    * [pysnooper](https://github.com/cool-RR/PySnooper) - Never use print for debugging again.
 
 ## Deep Learning
 

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [django-devserver](https://github.com/dcramer/django-devserver) - A drop-in replacement for Django's runserver.
     * [flask-debugtoolbar](https://github.com/mgood/flask-debugtoolbar) - A port of the django-debug-toolbar to flask.
     * [pyelftools](https://github.com/eliben/pyelftools) - Parsing and analyzing ELF files and DWARF debugging information.
-    * [pysnooper](https://github.com/cool-RR/PySnooper) - Never use print for debugging again.
+    * [pysnooper](https://github.com/cool-RR/PySnooper) - A poor man's debugger.
 
 ## Deep Learning
 


### PR DESCRIPTION
## What is this Python project?

PySnooper lets you print values except instead of carefully crafting the right print lines, you just add one decorator line to the function you're interested in. You'll get a play-by-play log of your function, including which lines ran and when, and exactly when local variables were changed.

## What's the difference between this Python project and similar ones?

Just slap the decorator on, as shown below, and redirect the output to a dedicated log file by specifying its path as the first argument.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
