### PR TITLE
Remove Python Testing podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,7 +1248,6 @@ Where to discover new Python libraries.
 * [From Python Import Podcast](http://frompythonimportpodcast.com/)
 * [Podcast.init](https://podcastinit.com/)
 * [Python Bytes](https://pythonbytes.fm)
-* [Python Testing](http://pythontesting.net)
 * [Radio Free Python](http://radiofreepython.com/)
 * [Talk Python To Me](https://talkpython.fm/)
 * [Test and Code](https://testandcode.com/)


### PR DESCRIPTION
This addresses issue #1205 

The new podcast location ([Test and Code](https://testandcode.com/)) was already on the list.