### PR TITLE
added django cachalot -  Caches Django ORM queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [beaker](https://github.com/bbangert/beaker) - A WSGI middleware for sessions and caching.
 * [django-cache-machine](https://github.com/django-cache-machine/django-cache-machine) - Automatic caching and invalidation for Django models.
 * [django-cacheops](https://github.com/Suor/django-cacheops) - A slick ORM cache with automatic granular event-driven invalidation.
+* [django-cachalot](https://github.com/noripyt/django-cachalot) - Django cachalot - Caches your Django ORM queries and automatically invalidates them.
 * [dogpile.cache](http://dogpilecache.readthedocs.io/en/latest/) - dogpile.cache is next generation replacement for Beaker made by same authors.
 * [HermesCache](https://pypi.org/project/HermesCache/) - Python caching library with tag-based invalidation and dogpile effect prevention.
 * [pylibmc](https://github.com/lericson/pylibmc) - A Python wrapper around the [libmemcached](https://libmemcached.org/libMemcached.html) interface.


### PR DESCRIPTION
added Django cachalot - Caches your Django ORM queries and automatically invalidates them.

