### PR TITLE
Add dontpady

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [itsdangerous](https://github.com/pallets/itsdangerous) - Various helpers to pass trusted data to untrusted environments.
 * [pluginbase](https://github.com/mitsuhiko/pluginbase) - A simple but flexible plugin system for Python.
 * [tryton](http://www.tryton.org/) - A general purpose business framework.
+* [dontpady](http://github.com/vgasparini/dontpady) - A CLI aplication to use [dontpad](http://dontpad.com).
 
 ## Natural Language Processing
 


### PR DESCRIPTION
## What is this Python project?

Dontpady is an simple CLI application to use [dontpad](https://dontpad.com)
It's possible to save text files and text input using a password to encrypt

Freatures:

*Write* from stdin input
*Write* from text file
*Write and read* using a crypt key

## What's the difference between this Python project and similar ones?

1. On dontpady (mine) you can write on repo directly from a file
2. On dontpady you can crypt you repo using a key, the hash is simple but usefull
3. On dontpady you can read or save an repo text easily

Comparisons:

https://github.com/GuilhermeFreire/dontpad (not updated since 10 months)

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
