### PR TITLE
Add webbrowser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1180,6 +1180,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [sumy](https://github.com/miso-belica/sumy) - A module for automatic summarization of text documents and HTML pages.
 * [textract](https://github.com/deanmalmgren/textract) - Extract text from any document, Word, PowerPoint, PDFs, etc.
 * [toapi](https://github.com/gaojiuli/toapi) - Every web site provides APIs.
+* [webbrowser](https://docs.python.org/2/library/webbrowser.html) - A module to open URLs in interactive browser applications.
 
 ## Web Crawling
 


### PR DESCRIPTION
## What is this Python project?

The webbrowser module includes functions to open URLs in interactive browser applications. The module includes a registry of available browsers, in case multiple options are available on the system. It can also be controlled with the BROWSER environment variable.

## What's the difference between this Python project and similar ones?

The URL is opened in a browser window, and that window is raised to the top of the window stack. An existing window will be reused, if possible, but the actual behavior may depend on your browser’s settings.
If for some reason your application needs to use a specific browser, you can access the set of registered browser controllers using the get() function. The browser controller has methods to open(), open_new(), and open_new_tab().
Users can control the module from outside your application by setting the environment variable BROWSER to the browser names or commands to try.
All of the features of the webbrowser module are available via the command line as well as from within your Python program.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
