### PR TITLE
Add signale.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.
     * [pgcli](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting.
     * [saws](https://github.com/donnemartin/saws) - A Supercharged [aws-cli](https://github.com/aws/aws-cli).
+    * [signale.py](https://github.com/ShardulNalegave/signale.py) - Elegant Console Logger For Python Command Line Apps
 
 ## Compatibility
 


### PR DESCRIPTION
Name:-
Signale.py

Description:-
Elegant Console Logger For Python Command-Line Apps

Installation:-
Available on PyPi can be installed using the command:-

    `[sudo] pip install signalepy`
GitHub Repository:-
[Repo](https://github.com/ShardulNalegave/signale.py)

Creator:-
[Shardul Nalegave](https://shardul.netlify.com/)
[Github Profile Page](https://github.com/ShardulNalegave)