### PR TITLE
Add py-couchdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [Telephus](https://github.com/driftx/Telephus) - Twisted based client for Cassandra.
     * [txpostgres](https://github.com/wulczer/txpostgres) - Twisted based asynchronous driver for PostgreSQL.
     * [txRedis](https://github.com/deldotdr/txRedis) - Twisted based client for Redis.
+    * [py-couchdb](https://github.com/histrio/py-couchdb) - Modern pure python CouchDB Client.
 
 ## Date and Time
 


### PR DESCRIPTION
## What is this Python project?

Modern pure python CouchDB Client. 

 - Use requests for HTTP requests (much faster than the standard library)
 - Python2 and Python3 compatible with same codebase (with one exception, python view server that uses 2to3)
 - Also compatible with pypy.

## What's the difference between this Python project and similar ones?

Currently, there are several libraries in python to connect to CouchDB. Why one more? It's very simple.

All seems not to be maintained, all libraries used standard Python libraries for HTTP requests, and are not compatible with python3.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
