### PR TITLE
Add sanic-openapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for generating project documentation.*
 
+* [sanic-openapi](https://github.com/huge-success/sanic-openapi) - Give your Sanic API a UI and OpenAPI documentation.
 * [sphinx](https://github.com/sphinx-doc/sphinx/) - Python Documentation generator.
     * [awesome-sphinxdoc](https://github.com/yoloseem/awesome-sphinxdoc)
 * [pdoc](https://github.com/mitmproxy/pdoc) - Epydoc replacement to auto generate API documentation for Python libraries.


### PR DESCRIPTION
## What is this Python project?

Give your Sanic API a UI and OpenAPI documentation, all for the price of free.

https://github.com/huge-success/sanic-openapi

## What's the difference between this Python project and similar ones?

It provides an easy way to create API documentation for Sanic with Swagger.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
