### PR TITLE
Add pytype

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Static Type Checkers, also see [awesome-python-typing](https://github.com/typeddjango/awesome-python-typing)
     * [mypy](http://mypy-lang.org/) - Check variable types during compile time.
     * [pyre-check](https://github.com/facebook/pyre-check) - Performant type checking.
+    * [pytype](https://github.com/google/pytype) - Checks and infers types for your Python code without requiring type annotations.
 * Static Type Annotations Generators
     * [MonkeyType](https://github.com/Instagram/MonkeyType) - A system for Python that generates static type annotations by collecting runtime types
 


### PR DESCRIPTION
## What is this Python project?

Pytype checks and infers types for your Python code - without requiring type annotations.
Thousands of projects at Google rely on pytype to keep their Python code well-typed and error-free.

https://github.com/google/pytype

## What's the difference between this Python project and similar ones?

- Supported by Google.
- Lint plain Python code, flagging common mistakes such as misspelled attribute names, incorrect function calls, and much more, even across file boundaries.
- Enforce user-provided type annotations. While annotations are optional for pytype, it will check and apply them where present.
- Generate type annotations in standalone files ("pyi files"), which can be merged back into the Python source with a provided merge-pyi tool.
- Pytype is a static analyzer; it does not execute the code it runs on.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
