### PR TITLE
Add git-me-the-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Productivity Tools
     * [cookiecutter](https://github.com/audreyr/cookiecutter) - A command-line utility that creates projects from cookiecutters (project templates).
     * [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
+    * [git-me-the-url](https://github.com/amykyta3/git-me-the-url) - Generate the public GitHub URL to a file tracked in Git.
     * [howdoi](https://github.com/gleitz/howdoi) - Instant coding answers via the command line.
     * [PathPicker](https://github.com/facebook/PathPicker) - Select files out of bash output.
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.


### PR DESCRIPTION
## What is this Python project?

[Git me the URL](https://github.com/amykyta3/git-me-the-url/blob/master/README.md) is a simple command line application that converts the path to a file in your Git repository into a public URL for popular Git hosting sites.

I also provide an API so that users can embed the translator into a larger project, as well as extend the command line tool to add custom path translations.

![gitmetheurl](https://raw.githubusercontent.com/amykyta3/git-me-the-url/master/docs/cmd-example.gif)

## What's the difference between this Python project and similar ones?

I have not been able to find anything else like it.
This is a very useful tool if you often share links to your source with co-workers/friends while collaborating on a project.
* Supports URL generation for popular Git hosting sites such as GitHub, GitLab, and Bitbucket.
* Easy to extend for other Git hosting services (public ones or private ones).
* Accurately points to the file under the correct branch or exact commit.
* Reference a line number, or range of lines.
* Copy URL directly to your clipboard.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
