### PR TITLE
Adds dry-python/returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [fn.py](https://github.com/kachayev/fn.py) - Functional programming in Python: implementation of missing features to enjoy FP.
 * [funcy](https://github.com/Suor/funcy) - A fancy and practical functional tools.
 * [Toolz](https://github.com/pytoolz/toolz) - A collection of functional utilities for iterators, functions, and dictionaries.
+* [returns](https://github.com/dry-python/returns) - A set of type-safe monads, tranformers, and composition utilities.
 
 ## GUI Development
 


### PR DESCRIPTION
## What is this Python project?

Make your functions return something meaningful, typed, and safe!

### Features

- Provides a bunch of primitives to write declarative business logic
- Enforces better architecture
- Fully typed with annotations and checked with `mypy`, [PEP561 compatible](https://www.python.org/dev/peps/pep-0561/)
- Has a bunch of helpers for better composition
- Pythonic and pleasant to write and to read (!)
- Support functions and coroutines, framework agnostic
- Easy to start: has lots of docs, tests, and tutorials

Link: https://github.com/dry-python/returns

Related:
- https://returns.readthedocs.io/en/latest/
- https://github.com/dry-python/classes
- https://sobolevn.me/2019/02/python-exceptions-considered-an-antipattern
- https://sobolevn.me/2019/03/enforcing-srp
- https://github.com/typeddjango/awesome-python-typing


## What's the difference between this Python project and similar ones?

Currently it is the only typed monads implementation I know. Other packages are not typed and not checked with `mypy`

Other similar projects are listed here: https://returns.readthedocs.io/en/latest/#inspirations
