### PR TITLE
Add pconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [configobj](https://github.com/DiffSK/configobj) - INI file parser with validation.
 * [configparser](https://docs.python.org/3/library/configparser.html) - (Python standard library) INI file parser.
+* [pconf](https://github.com/andrasmaroy/pconf) - Hierarchical configuration handler supporting multiple sources.
 * [profig](https://profig.readthedocs.io/en/default/) - Config from multiple formats with value conversion.
 * [python-decouple](https://github.com/henriquebastos/python-decouple) - Strict separation of settings from code.
 


### PR DESCRIPTION
## What is this Python project?

Supports parsing configuration values from multiple sources and organizing them in a hierarchy, meaning sources higher-up overwrite values with the same key.

Available sources:
* environment variables
* files
  * json
  * yaml
  * ini
  * custom formats also available
* command line arguments
* key-value pairs (`dict`) directly

## What's the difference between this Python project and similar ones?

I'm not aware of anything similar.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
