### PR TITLE
Added nosqlmodels

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [MongoEngine](http://mongoengine.org/) - A Python Object-Document-Mapper for working with MongoDB.
     * [PynamoDB](https://github.com/pynamodb/PynamoDB) - A Pythonic interface for [Amazon DynamoDB](https://aws.amazon.com/dynamodb/).
     * [redisco](https://github.com/kiddouk/redisco) - A Python Library for Simple Models and Containers Persisted in Redis.
+    * [nosqlmodel](https://gitlab.com/mozgurbayhan/nosqlmodel) - nosqlmodel is a first non-relational NoSql ORM framework.
 * Others
     * [butterdb](https://github.com/terrible-ideas/butterdb) - A Python ORM for Google Drive Spreadsheets.
     * [dataset](https://github.com/pudo/dataset) - A JSON-based database.


### PR DESCRIPTION
added nosqlmodels

## What is this Python project?

nosqlmodel is a first non-relational NoSql ORM framework. Easy way to create models with a nosql backend.

## What's the difference between this Python project and similar ones?

There is no smilar nosql ORM frameworks with multi backends.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
