### PR TITLE
add more-itertools

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Python implementation of algorithms and design patterns.*
 
 * [algorithms](https://github.com/keon/algorithms) - Minimal examples of data structures and algorithms in Python.
+* [more-itertools](https://github.com/erikrose/more-itertools) - More routines for operating on iterables, beyond `itertools`.
 * [PyPattyrn](https://github.com/tylerlaberge/PyPattyrn) - A simple yet effective library for implementing common design patterns.
 * [python-patterns](https://github.com/faif/python-patterns) - A collection of design patterns in Python.
 * [sortedcontainers](https://github.com/grantjenks/python-sortedcontainers) - Fast, pure-Python implementation of SortedList, SortedDict, and SortedSet types.


### PR DESCRIPTION
## What is this Python project?

From the README of the project:
> Python's `itertools` library is a gem - you can compose elegant solutions for a variety of problems with the functions it provides. In [`more-itertools`](https://github.com/erikrose/more-itertools) we collect additional building blocks, recipes, and routines for working with Python iterables.

## What's the difference between this Python project and similar ones?

`more-itertools` provides most re-usable functions one would want when working with iterables. By relying on this lightweight package, similarly to what `itertools` provide, one can write more readable and maintainable code, while avoiding having to re-invent the wheel (and introducing bugs by doing so).

As simple examples, instead of using raw iterators, one should use `itertools` when appropriate:
```Python
>>> from itertools import repeat

>>> (10 for _ in range(3))  # Instead of this ...
>>> repeat(10, 3)           # ... use that!
```
and `more-itertools` is based on the same idea and provides many more building blocks:
```Python
>>> from more_itertools import ilen

>>> sum(1 for _ in iter)  # Instead of this ...
>>> ilen(iter)            # ... use that!
```

Of course, the project also provides more advanced expressions, hard to express as one-liners. Some of my favourites (notice their high-quality documentation):
- [`all_equal(iterable)`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.all_equal)
- [`last(iterable[, default])`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.last)
- [`nth(iterable, n, default=None)`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.nth)
- [`consume(iterator, n=None)`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.consume)
- [`distribute(n, iterable)`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.distribute)
- [`roundrobin(*iterables)`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.roundrobin)
- [`windowed(seq, n, fillvalue=None, step=1)`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.windowed)
- [`substrings(iterable)`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.substrings)
- [`powerset(iterable)`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.powerset)
- [`random_permutation(iterable, r=None)`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.random_permutation)
- [`with_iter(context_manager)`](https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.with_iter)

In many cases where I wondered "Why didn't they implement this in `itertools`?!", `most-itertools` had a single-call solution: there's a reason why the project already has 1.2k :star: on GitHub!

Please give `most-itertools` a try and give this PR a :+1: if you find the package useful.