### PR TITLE
Add dephell

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,6 +865,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for package and dependency management.*
 
+* [dephell](https://github.com/dephell/dephell#readme) - Tool that augments other standard tools (pip, poetry, …) with missing features and workflows.
 * [pip](https://pip.pypa.io/en/stable/) - The package installer for Python.
     * [PyPI](https://pypi.org/)
     * [pip-tools](https://github.com/jazzband/pip-tools) - A set of tools to keep your pinned Python dependencies fresh.


### PR DESCRIPTION
Many features that make managing projects easier, and a replacement for the unmaintained pipsi (easy installation of scripts into dedicated venvs). It *adds* to existing tools like pip and poetry, instead of doing a bad replacement job.

https://github.com/dephell/dephell#readme

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
