### PR TITLE
Add ezpy/deadsnakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries to create packaged executables for release distribution.*
 
 * [dh-virtualenv](https://github.com/spotify/dh-virtualenv) - Build and distribute a virtualenv as a Debian package.
+* [ezpy/deadsnakes](https://github.com/jhermann/ezpy/tree/master/deadsnakes#readme) - A Dockerfile that builds Ubuntu's Deadsnakes PPA packages for Debian releases.
 * [Nuitka](http://nuitka.net/) - Compile scripts, modules, packages to an executable or extension module.
 * [py2app](http://pythonhosted.org/py2app/) - Freezes Python scripts (Mac OS X).
 * [py2exe](http://www.py2exe.org/) - Freezes Python scripts (Windows).


### PR DESCRIPTION
## What is this Python project?

Make Python 3.6 / 3.7 / 3.8 uniformly available on stable and old-stable Ubuntu and Debian (Xenial / Bionic / Stretch / Buster). Either to deploy easily to multiple Debian-based hosts in your ‘classic’ infrastructure, or to run unit tests on *one* host for *several* Python versions.

Disclaimer: I wrote it.

## What's the difference between this Python project and similar ones?

Unlike pyenv, this is ops-friendly because you get pre-built packages with the Python test suite checked. It's for those cases when a container just doesn't do the job.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
