### PR TITLE
Add py_cui and pyautogit projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for building command-line applications.*
 
 * Command-line Application Development
+    * [py_cui](https://github.com/jwlodek/py_cui) - A cross platform library for constructing TUI/CUI interfaces.
     * [cement](http://builtoncement.com/) - CLI Application Framework for Python.
     * [click](http://click.pocoo.org/dev/) - A package for creating beautiful command line interfaces in a composable way.
     * [cliff](https://docs.openstack.org/developer/cliff/) - A framework for creating command-line programs with multi-level commands.
@@ -268,6 +269,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Useful CLI-based tools for productivity.*
 
 * Productivity Tools
+    * [pyautogit](https://github.com/jwlodek/pyautogit) - A terminal user interface for managing multiple git repositories.
     * [cookiecutter](https://github.com/audreyr/cookiecutter) - A command-line utility that creates projects from cookiecutters (project templates).
     * [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
     * [howdoi](https://github.com/gleitz/howdoi) - Instant coding answers via the command line.


### PR DESCRIPTION
## What is this Python project?

[py_cui](https://github.com/jwlodek/py_cui) - A cross platform library for constructing TUI/CUI interfaces.

[pyautogit](https://github.com/jwlodek/pyautogit) - A terminal user interface for managing multiple git repositories.

## What's the difference between this Python project and similar ones?

`py_cui` - aimed at beginners, with the simplest possible syntax for constructing TUI interfaces. Can write functional programs like a TODO list in under 100 lines of code

`pyautogit` - Provides a simple and unique interface for managing multiple git repositories quickly and easily in the terminal

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
