### PR TITLE
add litecli to Command-line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [kube-shell](https://github.com/cloudnativelabs/kube-shell) - An integrated shell for working with the Kubernetes CLI.
     * [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.
     * [pgcli](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting.
+    * [litecli](https://github.com/dbcli/litecli) - SQLite CLI with autocompletion and syntax highlighting.
     * [saws](https://github.com/donnemartin/saws) - A Supercharged [aws-cli](https://github.com/aws/aws-cli).
 
 ## Compatibility


### PR DESCRIPTION
## What is this Python project?

CLI for SQLite Databases with auto-completion and syntax highlighting.

![Completion](https://raw.githubusercontent.com/dbcli/litecli/master/screenshots/litecli.png)

## Features

* SQLite client similar to [mycli](https://github.com/dbcli/mycli) and [pgcli](https://github.com/dbcli/pgcli)
* support for SQLite
* autocompletion
* syntax highlighting
* shortcuts
* color themes

## What's the difference between this Python project and similar ones?

There is no other SQLite CLI with autocomplete alternative currently.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
