### PR TITLE
Add micropipenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,6 +865,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for package and dependency management.*
 
+* [micropipenv](https://github.com/thoth-station/micropipenv) - A minimalistic tool for installing dependencies, primarily designed for containerized applications.
 * [pip](https://pip.pypa.io/en/stable/) - The package installer for Python.
     * [PyPI](https://pypi.org/)
     * [pip-tools](https://github.com/jazzband/pip-tools) - A set of tools to keep your pinned Python dependencies fresh.


### PR DESCRIPTION
## What is this Python project?

A single Python script that is capable of installing Python packages into environment, primarily designed for containerized Python applications, but not limited to them.

## What's the difference between this Python project and similar ones?

micropipenv supports all the well-known locking formats as used by pip-tools, Poetry or Pipenv. It is designed to be a single Python script with one optional dependency that is installing dependencies out of lock files without a need to install or distribute Poetry or Pipenv. Suitable for containerized Python applications where the overall image size and shipped software in the container image matters.

Why should I use micropipenv?

* I would like to have a tool that "rules them all" - one lightweight tool to support all Python dependency lock file managers (pip-tools, Poetry, Pipenv) and lets users decide what they want to use when deploying Python applications in containerized environments (e.g. Kubernetes, ...)

* I would like to have containerized Python applications as small as possible with minimum software shipped and required to build and run a Python application in production.

* I would like to convert files produced by Pipenv/Poetry to a pip-tools compatible output.
I don't want to install Pipenv/Poetry, but I would like to run a project that uses Pipenv/Poetry for dependency management (e.g. restricted environments).

* My Pipenv installation is broken and Pipenv upstream did not issue any new Pipenv release.

* I would like to deploy my application into a production environment and my application dependencies are managed by Pipenv/Poetry (dependencies are already resolved), but I don't want to run Pipenv/Poetry in production.

See [README](https://github.com/thoth-station/micropipenv) file or project description on [PyPI](https://pypi.org/project/micropipenv) for more enumerated comparison and key features.