### PR TITLE
add dynamic-conf under configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [configparser](https://docs.python.org/3/library/configparser.html) - (Python standard library) INI file parser.
 * [profig](https://profig.readthedocs.io/en/default/) - Config from multiple formats with value conversion.
 * [python-decouple](https://github.com/henriquebastos/python-decouple) - Strict separation of settings from code.
+* [dynamic-conf](github.com/jnoortheen/dynamic-conf) - Declarative way to manage configuration variables separated from source. 
 
 ## Cryptography
 


### PR DESCRIPTION
it is very simple script that I find very useful and better than python-decouple. 
- it supports both `.py` and `.env` config files
- the developer has to define the variables under the class to start using it. i.e. no disparity between `.env` and `.env.template`
- cli to create `.env` or `env.py` file during ci or docker image builds. 
- automatic value conversion based on type annotation

## What is this Python project?

Describe features.

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
