### PR TITLE
Add Real Python Podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -1249,6 +1249,7 @@ Where to discover new Python libraries.
 * [Radio Free Python](http://radiofreepython.com/)
 * [Talk Python To Me](https://talkpython.fm/)
 * [Test and Code](https://testandcode.com/)
+* [The Real Python Podcast](https://realpython.com/podcasts/rpp/)
 
 ## Twitter
 


### PR DESCRIPTION
## What is this Python project?

[Real Python](https://realpython.com/) is a repository of free and in-depth Python tutorials created by a team of professional Python developers around the world. 

We recently launched a new [Python podcast](https://realpython.com/podcasts/rpp/) with community interviews.

This PR adds a link to the podcast in the resources section.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
