### PR TITLE
Add pyarmor

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [py2exe](http://www.py2exe.org/) - Freezes Python scripts (Windows).
 * [PyInstaller](https://github.com/pyinstaller/pyinstaller) - Converts Python programs into stand-alone executables (cross-platform).
 * [pynsist](http://pynsist.readthedocs.io/en/latest/) - A tool to build Windows installers, installers bundle Python itself.
+* [pyarmor](https://github.com/dashingsoft/pyarmor) - A tool used to obfuscate python scripts, bind obfuscated scripts to fixed machine or expire obfuscated scripts.
 
 ## Documentation
 


### PR DESCRIPTION
## What is this Python project?

[PyArmor](https://github.com/dashingsoft/pyarmor) is a command line tool used to obfuscate python scripts, bind obfuscated scripts to fixed machine or expire obfuscated scripts.

The goal of PyArmor is to make Python applied to commercial application easily.

PyArmor is well [Documentation](https://pyarmor.readthedocs.io/en/latest/)

There is also a web-ui package [pyarmor-webui](https://github.com/dashingsoft/pyarmor-webui)

PyArmor is trusted by many corporations in different countries, for examples, IBM, GE, NEC, Panasonic, Fujitsu, Tencent...   

## What's the difference between this Python project and similar ones?

* Seamless Replacement
  The obfuscated script is a normal python script. With an extra runtime package `pytransform`, the plain Python scripts can be replaced with obfuscated ones seamlessly

* Runtime Obfuscation
  The byte code of each code object will be obfuscated as soon as code object completed execution, and f_locals of frame is cleared at the same time

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **20**.
