### PR TITLE
Add pydebug

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Others
     * [icecream](https://github.com/gruns/icecream) - Inspect variables, expressions, and program execution with a single, simple function call.
     * [django-debug-toolbar](https://github.com/jazzband/django-debug-toolbar) - Display various debug information for Django.
+    * [pydebug](https://github.com/benmezger/pydebug) - Quick debugging decorators with Django's debug settings support.
     * [django-devserver](https://github.com/dcramer/django-devserver) - A drop-in replacement for Django's runserver.
     * [flask-debugtoolbar](https://github.com/mgood/flask-debugtoolbar) - A port of the django-debug-toolbar to flask.
     * [pyelftools](https://github.com/eliben/pyelftools) - Parsing and analyzing ELF files and DWARF debugging information.


### PR DESCRIPTION
## What is this Python project?

A set of utilities which makes it easier to debug Python code. Pydebug respects Django's config. It checks if the decorator is running within a Django project and DEBUG is set to True. If it's set to False, it simply returns the function.

## What's the difference between this Python project and similar ones?

- Allows the debug decorators to be deployed in a Django application
- No need to import pdb on every function, as the decorator takes care of it
- Support for `pdb` and `ipdb` if installed.
--

Anyone who agrees with this pull request could submit an *Approve* review to it.
