### PR TITLE
Add Flask-restx

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,6 +956,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [eve](https://github.com/pyeve/eve) - REST API framework powered by Flask, MongoDB and good intentions.
     * [flask-api](https://github.com/flask-api/flask-api) - Browsable Web APIs for Flask.
     * [flask-restful](https://github.com/flask-restful/flask-restful) - Quickly building REST APIs for Flask.
+    * [flask-restx](https://github.com/python-restx/flask-restx) - Fully featured framework for fast, easy and documented API development with Flask.
 * Pyramid
     * [cornice](https://github.com/Cornices/cornice) - A RESTful framework for Pyramid.
 * Framework agnostic


### PR DESCRIPTION
## What is this Python project?
An extension for Flask that adds support for quickly building REST APIs. Its a fork of Flask-RESTPlus that is actively maintained by the community. It offers fast, easy and documented API development with Flask

## What's the difference between this Python project and similar ones?
 - It provides a coherent collection of decorators and tools to describe your API and expose its documentation properly (using Swagger).

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
