### PR TITLE
Add the Fil memory profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [pyringe](https://github.com/google/pyringe) - Debugger capable of attaching to and injecting code into Python processes.
     * [python-hunter](https://github.com/ionelmc/python-hunter) - A flexible code tracing toolkit.
 * Profiler
+    * [Fil](https://github.com/pythonspeed/filprofiler/) - A memory profiler aimed at data processing applications, e.g. those written by scientists and data scientists.
     * [line_profiler](https://github.com/rkern/line_profiler) - Line-by-line profiling.
     * [memory_profiler](https://github.com/fabianp/memory_profiler) - Monitor Memory usage of Python code.
     * [profiling](https://github.com/what-studio/profiling) - An interactive Python profiler.


### PR DESCRIPTION
## What is this Python project?

Fil is a memory profiler aimed at data batch processing applications.

## What's the difference between this Python project and similar ones?

1. Fil figures out _peak_ memory usage, and then tells you which function stacks were responsible for allocating it.
2. Fil can dump the source of allocations when your program crashes due to lack of memory.
3. Fil can track _any_ allocation made via standard C memory allocation APIs, not just Python-native code.
4. You get lovely flamegraphs, so you can visually see exactly where memory came from (https://pythonspeed.com/products/filmemoryprofiler/memory-graph.svg)

Compared to other tools:

* memory-profiler tells you how much a line of code has allocated, and that's it. So you need to manually apply it to each function that gets called, and it can be very easy to miss that one place where memory spiked by 1GB and then immediately dropped, because it's on a single line.
* tracemalloc can't handle non-Python memory allocations.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
