### PR TITLE
Add MeiliSearch-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [elasticsearch-py](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/index.html) - The official low-level Python client for [Elasticsearch](https://www.elastic.co/products/elasticsearch).
 * [elasticsearch-dsl-py](https://github.com/elastic/elasticsearch-dsl-py) - The official high-level Python client for Elasticsearch.
 * [django-haystack](https://github.com/django-haystack/django-haystack) - Modular search for Django.
+* [meilisearch-python](https://github.com/meilisearch/meilisearch-python) - Official wrapper for the open-source search engine [MeiliSearch](https://www.meilisearch.com/)
 * [pysolr](https://github.com/django-haystack/pysolr) - A lightweight Python wrapper for [Apache Solr](https://lucene.apache.org/solr/).
 * [whoosh](http://whoosh.readthedocs.io/en/latest/) - A fast, pure Python search engine library.
 


### PR DESCRIPTION
## What is this Python project?

A wrapper to integrate MeiliSearch open-source search engine in your python projects. Easy to integrate search engine, open-source, customizable, free and self-hosted. 

## What's the difference between this Python project and similar ones?

- Free relevant search, with almost no config and typo tolerance
- Official repository, regularly maintained/updated

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
