### PR TITLE
Add pyvips

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [scikit-image](http://scikit-image.org/) - A Python library for (scientific) image processing.
 * [thumbor](https://github.com/thumbor/thumbor) - A smart imaging service. It enables on-demand crop, re-sizing and flipping of images.
 * [wand](https://github.com/dahlia/wand) - Python bindings for [MagickWand](http://www.imagemagick.org/script/magick-wand.php), C API for ImageMagick.
-* [pyvips](https://github.com/jcupitt/pyvips/) - A fast image processing library with low memory needs.
+* [pyvips](https://github.com/libvips/pyvips) - A fast image processing library with low memory needs.
 
 ## Implementations
 

--- a/README.md
+++ b/README.md
@@ -716,11 +716,11 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [pyBarcode](https://pythonhosted.org/pyBarcode/) - Create barcodes in Python without needing PIL.
 * [pygram](https://github.com/ajkumar25/pygram) - Instagram-like image filters.
 * [python-qrcode](https://github.com/lincolnloop/python-qrcode) - A pure Python QR Code generator.
+* [pyvips](https://github.com/libvips/pyvips) - A fast image processing library with low memory needs.
 * [Quads](https://github.com/fogleman/Quads) - Computer art based on quadtrees.
 * [scikit-image](http://scikit-image.org/) - A Python library for (scientific) image processing.
 * [thumbor](https://github.com/thumbor/thumbor) - A smart imaging service. It enables on-demand crop, re-sizing and flipping of images.
 * [wand](https://github.com/dahlia/wand) - Python bindings for [MagickWand](http://www.imagemagick.org/script/magick-wand.php), C API for ImageMagick.
-* [pyvips](https://github.com/libvips/pyvips) - A fast image processing library with low memory needs.
 
 ## Implementations
 

--- a/README.md
+++ b/README.md
@@ -720,6 +720,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [scikit-image](http://scikit-image.org/) - A Python library for (scientific) image processing.
 * [thumbor](https://github.com/thumbor/thumbor) - A smart imaging service. It enables on-demand crop, re-sizing and flipping of images.
 * [wand](https://github.com/dahlia/wand) - Python bindings for [MagickWand](http://www.imagemagick.org/script/magick-wand.php), C API for ImageMagick.
+* [pyvips](https://github.com/jcupitt/pyvips/) - A fast image processing library with low memory needs.
 
 ## Implementations
 


### PR DESCRIPTION
**note:** This is a repost of https://github.com/vinta/awesome-python/pull/1101 -- that PR had 21 +1s, but was autoclosed for being stale.

[pyvips](https://github.com/libvips/pyvips) is a binding for the [libvips image processing library](https://libvips.github.io/libvips/). It's fast and only needs a little memory. 

For example, on this benchmark:

https://github.com/libvips/libvips/wiki/Speed-and-memory-use

It's 5x faster than ImageMagick and needs 10x less memory.

pyvips works on all python versions on all platforms, is LGPL, can be [simply installed with pip](https://pypi.org/project/pyvips/), has [complete documentation](https://libvips.github.io/pyvips), has a large test suite, and has no known memory leaks.