### PR TITLE
Add isort

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Code Linters
     * [flake8](https://pypi.org/project/flake8/) - A wrapper around `pycodestyle`, `pyflakes` and McCabe.
         * [awesome-flake8-extensions](https://github.com/DmytroLitvinov/awesome-flake8-extensions)
+    * [isort](https://github.com/timothycrosley/isort) - A Python utility / library to sort imports.
     * [pylama](https://github.com/klen/pylama) - A code audit tool for Python and JavaScript.
     * [pylint](https://www.pylint.org/) - A fully customizable source code analyzer.
     * [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) - The strictest and most opinionated python linter ever.


### PR DESCRIPTION
## What is this Python project?

isort is a Python utility / library to sort imports alphabetically, and automatically separated into sections and by type. It provides a command line utility, Python library and plugins for various editors to quickly sort all your imports.
(from https://github.com/timothycrosley/isort)

## What's the difference between this Python project and similar ones?

I don't know other similar Python projects, but isort is really useful tool.
We don't have to take care of imports order anymore by using isort.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
