### PR TITLE
Added makesite to static site generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,6 +1091,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [lektor](https://github.com/lektor/lektor) - An easy to use static CMS and blog engine.
 * [mkdocs](https://github.com/mkdocs/mkdocs/) - Markdown friendly documentation generator.
+* [makesite](https://github.com/sunainapai/makesite) - Simple, lightweight, and magic-free static site/blog generator (< 130 lines).
 * [nikola](https://github.com/getnikola/nikola) - A static website and blog generator.
 * [pelican](https://github.com/getpelican/pelican) - Static site generator that supports Markdown and reST syntax.
 


### PR DESCRIPTION
added makesite to static site generators

## What is this Python project?

Simple, lightweight, and magic-free static site/blog generator.

## What's the difference between this Python project and similar ones?

Very lightweight. Only 130 lines (excluding comments and empty lines).

Enumerate comparisons.

1. No setup required whatsoever. Run the script `makesite`. That's it. 
2. Deploys to `github-pages` very easily using Github Workflow
--

Anyone who agrees with this pull request could submit an *Approve* review to it.
