### PR TITLE
Add MindsDB to the ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,6 +829,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Spark ML](http://spark.apache.org/docs/latest/ml-guide.html) - [Apache Spark](http://spark.apache.org/)'s scalable Machine Learning library.
 * [vowpal_porpoise](https://github.com/josephreisinger/vowpal_porpoise) - A lightweight Python wrapper for [Vowpal Wabbit](https://github.com/JohnLangford/vowpal_wabbit/).
 * [xgboost](https://github.com/dmlc/xgboost) - A scalable, portable, and distributed gradient boosting library.
+* [MindsDB](https://github.com/mindsdb/mindsdb) - MindsDB is an open source AI layer for existing databases that allows you to effortlessly develop, train and deploy state-of-the-art machine learning models using standard queries.
 
 ## Microsoft Windows
 


### PR DESCRIPTION
Include MindsDB to the ML section

## What is this Python project?
MindsDB is an open-source AI layer for existing databases and provides an Explainable AutoML framework. It enables you to build, train and test state of the art ML models in as simple as one line of code, or one SQL query.

## What's the difference between this Python project and similar ones?

* Auto ML
* Explainable AI
* AI Layer for databases
* Self-hosted
* Simplicity (One line of code or one SQL query)

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
