### PR TITLE
Add ipychart

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Dash](https://plot.ly/products/dash/) - Built on top of Flask, React and Plotly aimed at analytical web applications.
     * [awesome-dash](https://github.com/Acrotrend/awesome-dash)
 * [diagrams](https://github.com/mingrammer/diagrams) - Diagram as Code.
+* [ipychart](https://github.com/nicohlr/ipychart) - Use Chart.js in Jupyter Notebook.
 * [Matplotlib](http://matplotlib.org/) - A Python 2D plotting library.
 * [plotnine](https://github.com/has2k1/plotnine) - A grammar of graphics for Python based on ggplot2.
 * [Pygal](http://www.pygal.org/en/latest/) - A Python SVG Charts Creator.


### PR DESCRIPTION
Add ipychart, a new data visualization library for the Jupyter Notebook environment powered by Chart.js, the famous Javascript library, in the backend.

Official documentation: https://nicohlr.gitlab.io/ipychart/
Github repo: https://github.com/nicohlr/ipychart