### PR TITLE
[code analysis tools] Add fixit

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [pycallgraph](https://github.com/gak/pycallgraph) - A library that visualises the flow (call graph) of your Python application.
     * [vulture](https://github.com/jendrikseipp/vulture) - A tool for finding and analysing dead Python code.
 * Code Linters
+    * [fixit](https://pypi.org/project/fixit/) - A framework for creating lint rules and corresponding auto-fixes for source code.
     * [flake8](https://pypi.org/project/flake8/) - A wrapper around `pycodestyle`, `pyflakes` and McCabe.
         * [awesome-flake8-extensions](https://github.com/DmytroLitvinov/awesome-flake8-extensions)
     * [pylama](https://github.com/klen/pylama) - A code audit tool for Python and JavaScript.


### PR DESCRIPTION
## What is this Python project?

Fixit allows the creation of custom lint rules, just like flake8 or pylint. In addition, fixit allows developers to apply code transformations, similar to 2to3.

## What's the difference between this Python project and similar ones?


flake8/pyflakes and pylint use the `ast` or `astroid` modules to analyze the source code. The resulting abstract syntax tree is missing information, such as whether a string was surrounded by single or double quotes, or the number of whitespaces between two tokens. Fixit is based on libCST, which uses a concrete syntax tree as its base representation and retains all formatting.

Therefore, Fixit is not just a framework for lint rules, but a framework for code transformations. This can be used to enforce coding conventions or to ascertain certain properties of the source code like HTTP request timeouts.
--

Anyone who agrees with this pull request could submit an *Approve* review to it.
