### PR TITLE
Add Here API geocoder Client Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [geojson](https://github.com/frewsxcv/python-geojson) - Python bindings and utilities for GeoJSON.
 * [geopy](https://github.com/geopy/geopy) - Python Geocoding Toolbox.
 * [pygeoip](https://github.com/appliedsec/pygeoip) - Pure Python GeoIP API.
+* [heregeocoder](https://github.com/kaypee90/here_geocoder_wrapper) - A python client library for the HERE GEOCODER API
 
 ## HTML Manipulation
 


### PR DESCRIPTION
## What is this Python project?

Provides a client library for interacting with here geocoder api

## What's the difference between this Python project and similar ones?

HERE exposes a number of rest APIs and this library is intended to make it even easier for python programmers to use the geocoder API. 

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
