### PR TITLE
Add flask-state

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,6 +854,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [blinker](https://github.com/jek/blinker) - A fast Python in-process signal/event dispatching system.
 * [boltons](https://github.com/mahmoud/boltons) - A set of pure-Python utilities.
+* [flask-state](https://github.com/yoobool/flask-state) - Display machine state using Python3 with Flask.
 * [itsdangerous](https://github.com/pallets/itsdangerous) - Various helpers to pass trusted data to untrusted environments.
 * [magenta](https://github.com/magenta/magenta) - A tool to generate music and art using artificial intelligence.
 * [pluginbase](https://github.com/mitsuhiko/pluginbase) - A simple but flexible plugin system for Python.


### PR DESCRIPTION
## What is this Python project?

Flask-State is a lightweight chart plugin to show machine state.

- Monitoring indicators: CPU, Memory, Disk usage, LoadAVG, Boot time.
- Extensible: It has rich options for extended functions, including redis monitoring, user authentication, custom logging, i18n and etc.
- Stable: Lightweight dependencies, meanwhile solving multi-progress concurrency problems (if you use gunicorn).

## What's the difference between this Python project and similar ones?

I don't know other similar Python projects.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
