### PR TITLE
Add pdfminer.six

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,7 +1095,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [xlwings](https://github.com/ZoomerAnalytics/xlwings) - A BSD-licensed library that makes it easy to call Python from Excel and vice versa.
     * [xlwt](https://github.com/python-excel/xlwt) / [xlrd](https://github.com/python-excel/xlrd) - Writing and reading data and formatting information from Excel files.
 * PDF
-    * [PDFMiner](https://github.com/euske/pdfminer) - A tool for extracting information from PDF documents.
+    * [pdfminer.six](https://github.com/pdfminer/pdfminer.six) - Pdfminer.six is a community maintained fork of the original PDFMiner.
     * [PyPDF2](https://github.com/mstamy2/PyPDF2) - A library capable of splitting, merging and transforming PDF pages.
     * [ReportLab](https://www.reportlab.com/opensource/) - Allowing Rapid creation of rich PDF documents.
 * Markdown


### PR DESCRIPTION
## What is this Python project?

[Pdfminer.six](https://github.com/pdfminer/pdfminer.six) is a community maintained fork of the original [PDFMiner](https://github.com/euske/pdfminer). It is a tool for extracting information from PDF documents.

## What's the difference between this Python project and similar ones?

> As of 2020, `PDFMiner` is not actively maintained. For the active project, check out its fork `pdfminer.six`.

So I change `PDFMiner` to `pdfminer.six`

----

Anyone who agrees with this pull request could submit an *Approve* review to it.
