### PR TITLE
Added deprecation disclaimer for PyUserInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [keyboard](https://github.com/boppreh/keyboard) - Hook and simulate global keyboard events on Windows and Linux.
 * [mouse](https://github.com/boppreh/mouse) - Hook and simulate global mouse events on Windows and Linux.
 * [Pingo](http://www.pingo.io/) - Pingo provides a uniform API to program devices like the Raspberry Pi, pcDuino, Intel Galileo, etc.
-* [PyUserInput](https://github.com/SavinaRoja/PyUserInput) - A module for cross-platform control of the mouse and keyboard.
+* (deprecated) [PyUserInput](https://github.com/SavinaRoja/PyUserInput) - A module for cross-platform control of the mouse and keyboard.
 * [scapy](https://github.com/secdev/scapy) - A brilliant packet manipulation library.
 * [wifi](https://github.com/rockymeza/wifi) - A Python library and command line tool for working with WiFi on Linux.
 


### PR DESCRIPTION
## What is this Python project?

Was deprecated because the dependencies are reliant on py2 and nobody is working on it.
 

Anyone who agrees with this pull request could submit an *Approve* review to it.
