### PR TITLE
📝 Updated line_profiler repo location

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [pyringe](https://github.com/google/pyringe) - Debugger capable of attaching to and injecting code into Python processes.
     * [python-hunter](https://github.com/ionelmc/python-hunter) - A flexible code tracing toolkit.
 * Profiler
-    * [line_profiler](https://github.com/rkern/line_profiler) - Line-by-line profiling.
+    * [
+    ](https://github.com/pyutils/line_profiler) - Line-by-line profiling.
     * [memory_profiler](https://github.com/fabianp/memory_profiler) - Monitor Memory usage of Python code.
     * [profiling](https://github.com/what-studio/profiling) - An interactive Python profiler.
     * [py-spy](https://github.com/benfred/py-spy) - A sampling profiler for Python programs. Written in Rust.


### PR DESCRIPTION
The original line_profiler repo is no longer maintained and links to this new maintained repo.
Old Repo: https://github.com/rkern/line_profiler
New Repo: https://github.com/pyutils/line_profiler

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
