### PR TITLE
🗑 Remove profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,6 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Profiler
     * [line_profiler](https://github.com/rkern/line_profiler) - Line-by-line profiling.
     * [memory_profiler](https://github.com/fabianp/memory_profiler) - Monitor Memory usage of Python code.
-    * [profiling](https://github.com/what-studio/profiling) - An interactive Python profiler.
     * [py-spy](https://github.com/benfred/py-spy) - A sampling profiler for Python programs. Written in Rust.
     * [pyflame](https://github.com/uber/pyflame) - A ptracing profiler For Python.
     * [vprof](https://github.com/nvdv/vprof) - Visual Python profiler.


### PR DESCRIPTION
Remove the profiling repo as it has been archived and no longer maintained. The repo owner is highly recommending people switching to py-spy which provides better performance and usability.
Repo: https://github.com/what-studio/profiling

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
