### PR TITLE
🗑 Remove pygeoip

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,7 +710,6 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [GeoIP](https://github.com/maxmind/geoip-api-python) - Python API for MaxMind GeoIP Legacy Database.
 * [geojson](https://github.com/frewsxcv/python-geojson) - Python bindings and utilities for GeoJSON.
 * [geopy](https://github.com/geopy/geopy) - Python Geocoding Toolbox.
-* [pygeoip](https://github.com/appliedsec/pygeoip) - Pure Python GeoIP API.
 
 ## HTML Manipulation
 


### PR DESCRIPTION
Repo is no longer supported, is archived and read-only. Maintainer is recommending people use the Maxmind's GeoIP2 Python API.
Maxmind's GeoIP2 Python API.: https://github.com/maxmind/GeoIP2-python
pygeoip: https://github.com/appliedsec/pygeoip

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
