### PR TITLE
Add Thoth's configuration file for Kebechet bot

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -1,0 +1,31 @@
+# A remote Thoth service to talk to:
+host: khemenu.thoth-station.ninja
+
+# Configure TLS verification for communication with remote Thoth instance:
+tls_verify: true
+
+# Format of requirements file, supported are "pip" and "pipenv":
+requirements_format: pip
+
+#
+# Configuration of bots:
+#
+managers:
+  - name: version
+    configuration:
+      # A list of maintainers (GitHub or GitLab accounts) of this repository:
+      maintainers: ["vinta"]
+      # A list of assignees to which the opened pull requests and issues should
+      # be assigned to:
+      assignees: ["vinta"]
+      # Labels for issues and pull requests:
+      labels:
+        - bot
+      # Automatically maintain a changelog file stating features of new
+      # releases:
+      changelog_file: true
+      # Use AI/ML to group messages in a smart way.
+      changelog_smart: true
+  - name: update
+    configuration:
+      labels: [bot]


### PR DESCRIPTION
As discussed in https://github.com/vinta/awesome-python/issues/1619#issuecomment-756729525 adding a bot that can automatically manage the repository, track changelog, and take care of project version lifecycle. The bot will check the repository setup once it is enabled by the repository maintainer (@vinta). Please [follow the instructions in docs](https://thoth-station.ninja/docs/developers/adviser/integration.html#kebechet-github-application) for more info. Basically, you'll need to enable https://github.com/apps/khebhut application and let @sesheta be the collaborator of the repo so it can open PRs.

Let us know if you have any issues, questions or you find any difficulties with the setup. We are happy to help.