### PR TITLE
add cx_oracle to Database Drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [pymssql](https://pymssql.readthedocs.io/en/latest/) - A simple database interface to Microsoft SQL Server.
     * [SuperSQLite](https://github.com/plasticityai/supersqlite) - A supercharged SQLite library built on top of [apsw](https://github.com/rogerbinns/apsw).
     * [clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver) - Python driver with native interface for ClickHouse.
+    * [cx_Oracle](https://github.com/oracle/python-cx_Oracle) - Python interface to Oracle Database conforming to the Python DB API 2.0 specification.
 * NoSQL Databases
     * [cassandra-driver](https://github.com/datastax/python-driver) - The Python Driver for Apache Cassandra.
     * [happybase](https://github.com/wbolster/happybase) - A developer-friendly library for Apache HBase.


### PR DESCRIPTION
## What is this Python project?

Oracle's own database driver for working with Oracle SQL databases

## What's the difference between this Python project and similar ones?

There are no other drivers for Oracle SQL databases.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
