### PR TITLE
add traitlets

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Box](https://github.com/cdgriffith/Box) - Python dictionaries with advanced dot notation access.
 * [dataclasses](https://docs.python.org/3/library/dataclasses.html) - (Python standard library) Data classes.
 * [DottedDict](https://github.com/carlosescri/DottedDict) - A library that provides a method of accessing lists and dicts with a dotted path notation.
+* [Traitlets](https://github.com/ipython/traitlets) - A library that enables enforcement of strong typing of attributes, dynamic calculation of default values, and automatic validation when values change.
 
 ## CMS
 


### PR DESCRIPTION
## What is this Python project?
Traitlets is a pure Python library enabling:

-     the enforcement of strong typing for attributes of Python objects (typed attributes are called "traits");
-     dynamically calculated default values;
-     automatic validation and coercion of trait attributes when attempting a change;
-     registering for receiving notifications when trait values change;
-     reading configuring values from files or from command line arguments - a distinct layer on top of traitlets, so you may use traitlets without the configuration machinery.

Its implementation relies on the descriptor pattern, and it is a lightweight pure-python alternative of the traits library.


## What's the difference between this Python project and similar ones?

- Pure Python
- configurable from file or CLI arguments

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
