### PR TITLE
Add Ariadne GraphQL library

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for working with GraphQL.*
 
+* [ariadne](https://ariadnegraphql.org/) - A library for implementing GraphQL servers using schema-first approach.
 * [graphene](https://github.com/graphql-python/graphene/) - GraphQL framework for Python.
 * [tartiflette-aiohttp](https://github.com/tartiflette/tartiflette-aiohttp/) - An `aiohttp`-based wrapper for Tartiflette to expose GraphQL APIs over HTTP.
 * [tartiflette-asgi](https://github.com/tartiflette/tartiflette-asgi/) - ASGI support for the Tartiflette GraphQL engine.


### PR DESCRIPTION
## What is this Python project?

Ariadne is a Python library for implementing GraphQL servers using a schema-first approach. 

## What's the difference between this Python project and similar ones?

Schema-first approach - unlike graphene the schema is defined explicitly and is not inferred from code, it's more light-weight and less opinionated, it has subscriptions, file uploads  tracing and other useful stuff built-in.

Example hello world app with starlette:
```py
from ariadne import QueryType, make_executable_schema
from ariadne.asgi import GraphQL
from starlette.applications import Starlette

type_defs = """
    type Query {
        hello: String!
    }
"""

query = QueryType()


@query.field("hello")
def resolve_hello(*_):
    return "Hello world!"


# Create executable schema instance
schema = make_executable_schema(type_defs, query)

app = Starlette(debug=True)
app.mount("/graphql", GraphQL(schema, debug=True))

```

Here's a shot intro from one of the authors: https://blog.mirumee.com/schema-first-graphql-the-road-less-travelled-cf0e50d5ccff


Anyone who agrees with this pull request could submit an *Approve* review to it.
