### PR TITLE
Add celery-exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,10 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [saltstack](https://github.com/saltstack/salt) - Infrastructure automation and management system.
 * [supervisor](https://github.com/Supervisor/supervisor) - Supervisor process control system for UNIX.
 
+*Monitoring tools.*
+
+* [celery-exporter](https://github.com/danihodovic/celery-exporter) - A Prometheus exporter for Celery metrics.
+
 ## Distributed Computing
 
 *Frameworks and libraries for Distributed Computing.*


### PR DESCRIPTION
## What is this Python project?

A Prometheus exporter for Celery metrics.

## What's the difference between this Python project and similar ones?

Explained in the 'Why?' section: https://github.com/danihodovic/celery-exporter/#why-another-exporter

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
