### PR TITLE
Add liquidb to ORM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,6 +908,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * Relational Databases
     * [Django Models](https://docs.djangoproject.com/en/dev/topics/db/models/) - The Django ORM.
+    * [django-liquidb](https://github.com/Gusakovskiy/django-liquidb) - Django application to simplify migration management and changes in states of db scheme.
     * [SQLAlchemy](https://www.sqlalchemy.org/) - The Python SQL Toolkit and Object Relational Mapper.
         * [awesome-sqlalchemy](https://github.com/dahlia/awesome-sqlalchemy)
     * [dataset](https://github.com/pudo/dataset) - Store Python dicts in a database - works with SQLite, MySQL, and PostgreSQL.


### PR DESCRIPTION
## What is this Python project?

Liquidb simplifies migration burden in big Django projects. One of useful use cases to quickly change state of DB schema in Django project that has with few codependent Django applications. Another example is to rollback to given state, so that code in Django project is consistent with DB schema.

## What's the difference between this Python project and similar ones?
There is no similar projects for Django in Python as far as I know. 

Anyone who agrees with this pull request could submit an *Approve* review to it.
