### PR TITLE
Add aiohttp-rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1018,6 +1018,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *RPC-compatible servers.*
 
+* [aiohttp-rpc](https://github.com/expert-m/aiohttp-rpc) - A library for a simple integration of the JSON-RPC 2.0 protocol to a Python application using [aiohttp](https://github.com/aio-libs/aiohttp).
 * [RPyC](https://github.com/tomerfiliba/rpyc) (Remote Python Call) - A transparent and symmetric RPC library for Python
 * [zeroRPC](https://github.com/0rpc/zerorpc-python) - zerorpc is a flexible RPC implementation based on [ZeroMQ](http://zeromq.org/) and [MessagePack](http://msgpack.org/).
 


### PR DESCRIPTION
## What is this Python project?

A library for a simple integration of the JSON-RPC 2.0 protocol to a Python application using aiohttp. The motivation is to provide a simple, fast and reliable way to integrate the JSON-RPC 2.0 protocol into your application on the server and/or client side. 

## What's the difference between this Python project and similar ones?

* Features
* Code quality
* Good abstractions

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
