### PR TITLE
Added "Projects" section and "DevProjects" under ##Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1337,6 +1337,8 @@ Where to discover learning resources or new Python libraries.
     * [Ultimate Python study guide](https://github.com/huangsam/ultimate-python)
 * Libraries
     * [Awesome Python @LibHunt](https://python.libhunt.com/)
+* Projects
+    * [DevProjects: Real-World Python Projects](https://www.codementor.io/projects/python)
 * Others
     * [Python ZEEF](https://python.zeef.com/alan.richmond)
     * [Pythonic News](https://news.python.sc/)
@@ -1368,4 +1370,3 @@ I will keep some pull requests open if I'm not sure whether those libraries are 
 - - -
 
 If you have any question about this opinionated list, do not hesitate to contact me [@VintaChen](https://twitter.com/VintaChen) on Twitter or open an issue on GitHub.
-


### PR DESCRIPTION
Hi, I'm a UX designer/marketer who has been learning a bit of Python on my own. I recently discovered DevProjects and wanted to include them in the list because I personally find the projects and community useful and interactive! Since I'm a beginner, I find other people's solutions helpful.

## What is this Python project?

I didn't choose a specific Python project from DevProjects, but I find the projects helpful as they're categorized as easy, medium, and difficult. As I'm new to Python, I usually try my hands on the easy ones, look at other people's solutions, and look at what the community is discussing about for each project. I like that new projects are added once in a while and that the website is completely free. 

## What's the difference between this Python project and similar ones?

DevProjects is very organized and doesn't give you step by step instructions on how to complete the projects. It challenges you to think on your own, but all the projects have really clearly written requirements and suggested implementations, and I like that you can read other people's solutions and comments on different projects.

Enumerate comparisons.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
