### PR TITLE
add deep-translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1215,6 +1215,9 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [python-user-agents](https://github.com/selwin/python-user-agents) - Browser user agent parser.
     * [sqlparse](https://github.com/andialbrecht/sqlparse) - A non-validating SQL parser.
 
+## Text Translation
+* [deep-translator](https://github.com/nidhaloff/deep-translator) - A flexible free and unlimited python tool to translate between different languages in a simple way using multiple translators.
+
 ## Third-party APIs
 
 *Libraries for accessing third party services APIs. Also see [List of Python API Wrappers and Libraries](https://github.com/realpython/list-of-python-api-wrappers).*


### PR DESCRIPTION
## What is this Python project?

A flexible free and unlimited python tool to translate between different languages in a simple way using multiple translators.

Describe features.

* Support for google translate
* Support for the microsoft translator
* Support for Pons translator
* Support for the Linguee translator
* Support for the Mymemory translator
* Support for the Yandex translator
* Support for the QCRI translator
* Support for the DeepL translator
* Support for proxy usage
* Automatic single language detection
* Batch language detection
* Translate directly from a text file
* Get multiple translations for a word
* Automate the translation of different paragraphs in different languages
* Translate directly from the terminal


## What's the difference between this Python project and similar ones?

As far as I know, there is no similar tool 

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
