### PR TITLE
add pyc2pa

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [nude.py](https://github.com/hhatto/nude.py) - Nudity detection.
 * [pagan](https://github.com/daboth/pagan) - Retro identicon (Avatar) generation based on input string and hash.
 * [pillow](https://github.com/python-pillow/Pillow) - Pillow is the friendly [PIL](http://www.pythonware.com/products/pil/) fork.
+* [pyc2pa] (https://github.com/numbersprotocol/pyc2pa) - Create authentic & traceable photos by embedding metadata according to Adobe's Content Authenticity standards and C2PA spec.
 * [python-barcode](https://github.com/WhyNotHugo/python-barcode) - Create barcodes in Python with no extra dependencies.
 * [pygram](https://github.com/ajkumar25/pygram) - Instagram-like image filters.
 * [PyMatting](http://github.com/pymatting/pymatting) - A library for alpha matting.


### PR DESCRIPTION
## What is this Python project?

PyC2PA is Python implementation of C2PA (Coalition for Content Provenance and Authenticity) addressing the prevalence of misleading information online through the development of technical standards for certifying the source and history (or provenance) of media content.

Describe features.

- Inject metadata into JPEG files using JUMBF injection
- Support for Single & Multiple Injection
- Injected JPEG files will have metadata embedded into photo itself making it traceable across the web
- Injected JPEG files verifiable with CAI Verification Website (https://verify.contentauthenticity.org/)

## What's the difference between this Python project and similar ones?

This is the first project that injects CAI metadata into photos. Content Authenticity Initiative is headed by Adobe and C2PA specs are headed by Adobe, Microsoft and other technology companies. Its a movement to create authentic digital assets in a time where misinformation is very prevalent.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
