### PR TITLE
Added vmam

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [cookiecutter](https://github.com/audreyr/cookiecutter) - A command-line utility that creates projects from cookiecutters (project templates).
     * [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
     * [howdoi](https://github.com/gleitz/howdoi) - Instant coding answers via the command line.
+    * [vmam](https://github.com/MatteoGuadrini/vmam) - VLAN Mac-address Authentication Manager.
     * [Invoke](https://github.com/pyinvoke/invoke#readme) - A tool for managing shell-oriented subprocesses and organizing executable Python code into CLI-invokable tasks.
     * [PathPicker](https://github.com/facebook/PathPicker) - Select files out of bash output.
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.


### PR DESCRIPTION
## What is this Python project?

`vmam` is a Free and Open Source network access control (NAC) solution. that access the network under a specific domain and a specific VLAN, through LDAP authentication and RADIUS server. This is based on [RFC 3579](https://tools.ietf.org/html/rfc3579#section-2.1).
Basically it creates mac-address users that represent the network card of a machine and associates these users with LDAP groups that represent the various VLANs specified created on their own network architecture.

## What's the difference between this Python project and similar ones?

* Work with an open source LDAP server or Active Directory
* Have a manual mode
* Have an automatic mode
* Use it in command line or as a python module

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
