### PR TITLE
Add Dataconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [configobj](https://github.com/DiffSK/configobj) - INI file parser with validation.
 * [configparser](https://docs.python.org/3/library/configparser.html) - (Python standard library) INI file parser.
+* [dataconf](https://github.com/zifeo/dataconf) - Dataconf is a simple dataclasses configuration management for Python based on lightweight pyhocon parsing library.
 * [hydra](https://github.com/facebookresearch/hydra) - Hydra is a framework for elegantly configuring complex applications.
 * [profig](https://profig.readthedocs.io/en/latest/) - Config from multiple formats with value conversion.
 * [python-decouple](https://github.com/henriquebastos/python-decouple) - Strict separation of settings from code.


### PR DESCRIPTION
## Dataconf

Dataconf is a simple dataclasses configuration management for Python with hocon/json/yaml/properties/env-vars/dict support, based on awesome and lightweight pyhocon parsing library.

