### PR TITLE
Add Raylib-Python-CFFI

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [PyOgre](http://www.ogre3d.org/tikiwiki/PyOgre) - Python bindings for the Ogre 3D render engine, can be used for games, simulations, anything 3D.
 * [PyOpenGL](http://pyopengl.sourceforge.net/) - Python ctypes bindings for OpenGL and it's related APIs.
 * [PySDL2](https://pysdl2.readthedocs.io) - A ctypes based wrapper for the SDL2 library.
+* [Raylib-Python-CFFI](https://electronstudio.github.io/raylib-python-cffi/) - Python Bindings for Raylib 4.0 - a library to enjoy videogames programming.
 * [RenPy](https://www.renpy.org/) - A Visual Novel engine.
 
 ## Geolocation


### PR DESCRIPTION
## What is this Python project?

Raylib is a simple library for videogames programming. This set of static bindings provides a fast and familier interface with the original Raylib 4.0 API. Genuinly suprised to not see any python-raylib bindings already, so I'd very much like to suggest this package be the one featured on this fantastic list.

## What's the difference between this Python project and similar ones?

- Automatically generated to be as close as possible to original Raylib.
- Faster, fewer bugs and easier to maintain than ctypes.
- Commercial-friendly license.
-  Docstrings and auto-completion.
- Now includes extra libraries: raygui, rlgl and physac
--

Anyone who agrees with this pull request could submit an *Approve* review to it.
