### PR TITLE
Add cachetools

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for caching data.*
 
 * [beaker](https://github.com/bbangert/beaker) - A WSGI middleware for sessions and caching.
+* [cachetools](https://github.com/bbangert/beaker) - Extensions to the builtin [functools.cache](https://docs.python.org/3/library/functools.html#functools.cache) to cache function/method outputs.
 * [django-cache-machine](https://github.com/django-cache-machine/django-cache-machine) - Automatic caching and invalidation for Django models.
 * [django-cacheops](https://github.com/Suor/django-cacheops) - A slick ORM cache with automatic granular event-driven invalidation.
 * [dogpile.cache](http://dogpilecache.readthedocs.io/en/latest/) - dogpile.cache is next generation replacement for Beaker made by same authors.


### PR DESCRIPTION
## cachetools

The [cachetools](https://cachetools.readthedocs.io/en/stable/) module provides various memoizing collections and decorators, including variants of the Python Standard Library’s [@lru_cache](http://docs.python.org/3/library/functools.html#functools.lru_cache) function decorator.

For the purpose of this module, a cache is a [mutable](http://docs.python.org/dev/glossary.html#term-mutable) [mapping](http://docs.python.org/dev/glossary.html#term-mapping) of a fixed maximum size. When the cache is full, i.e. by adding another item the cache would exceed its maximum size, the cache must choose which item(s) to discard based on a suitable [cache algorithm](http://en.wikipedia.org/wiki/Cache_algorithms).

This module provides multiple cache classes based on different cache algorithms, as well as decorators for easily memoizing function and method calls.

## What's the difference between this Python project and similar ones?

This module provides many useful variants and extensions of the Python Standard Library’s [@lru_cache (http://docs.python.org/3/library/functools.html#functools.lru_cache) function decorator.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
