### PR TITLE
Add pypi-command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [Invoke](https://github.com/pyinvoke/invoke#readme) - A tool for managing shell-oriented subprocesses and organizing executable Python code into CLI-invokable tasks.
     * [PathPicker](https://github.com/facebook/PathPicker) - Select files out of bash output.
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.
+    * [pypi-command-line](https://github.com/wasi-master/pypi-command-line) - A powerful, colorful, beautiful command-line-interface for pypi.org.
     * [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
     * [tmuxp](https://github.com/tony/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.
     * [try](https://github.com/timofurrer/try) - A dead simple CLI to try out python packages - it's never been easier.


### PR DESCRIPTION
## What is this Python project?

It's a command line interface for [pypi.org](https://pypi-org "The Python Package Index (PyPI) is a repository of software for the Python programming language.")

## What's the difference between this Python project and similar ones?

I've personally used it extensively and can say for sure that this is better than the alternatives. There also seems to be a [detailed comparison in the docs](https://wasi-master.github.io/pypi-command-line/#alternatives)

Anyone who agrees with this pull request could submit an *Approve* review to it.
