### PR TITLE
Add django-rest-framework-simplejwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [pyjwt](https://github.com/jpadilla/pyjwt) - JSON Web Token implementation in Python.
     * [python-jose](https://github.com/mpdavis/python-jose/) - A JOSE implementation in Python.
     * [python-jwt](https://github.com/davedoesdev/python-jwt) - A module for generating and verifying JSON Web Tokens.
+    * [django-rest-framework-simplejwt](https://django-rest-framework-simplejwt.readthedocs.io/en/latest/index.html) - A JSON Web Token authentication plugin for the Django REST Framework.
 
 ## Build Tools
 


### PR DESCRIPTION
## What is this Python project?

Easy. Awesome. 
Simple JWT provides a JSON Web Token authentication backend for the Django REST Framework.
It aims to cover the most common use cases of JWTs by offering a conservative set of default features. It also aims to be easily extensible in case a desired feature is not present.

## What's the difference between this Python project and similar ones?

https://github.com/jpadilla/django-rest-framework-jwt
- No more updates since August 13, 2019
- So it is right to use simplejwt


--

Anyone who agrees with this pull request could submit an *Approve* review to it.
