### PR TITLE
Add Chaos Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [psutil](https://github.com/giampaolo/psutil) - A cross-platform process and system utilities module.
 * Backup
     * [BorgBackup](https://www.borgbackup.org/) - A deduplicating archiver with compression and encryption.
+* Chaos Engineering
+    * [Chaos Toolkit](https://chaostoolkit.org/) - Chaos Engineering toolkit for developers.
 * Others
     * [docker-compose](https://docs.docker.com/compose/) - Fast, isolated development environments using [Docker](https://www.docker.com/).
 


### PR DESCRIPTION
Signed-off-by: Sylvain Hellegouarch <sh@defuze.org>

## What is this Python project?

Chaos Toolkit is a leading chaos engineering engineering engine. It's been around for almost 5 years and has grown a very nice friendly user base and is used in large organisations across industries.

## What's the difference between this Python project and similar ones?

None known at this time.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
