### PR TITLE
Add aiomysql and aiopg

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,8 +428,10 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [pymongo](https://github.com/mongodb/mongo-python-driver) - The official Python client for MongoDB.
     * [redis-py](https://github.com/andymccurdy/redis-py) - The Python client for Redis.
 * Asynchronous Clients
+    * [aiomysql](https://github.com/aio-libs/aiomysql) - aiomysql is a library for accessing a MySQL database from the asyncio.
+    * [aiopg](https://github.com/aio-libs/aiopg) - aiopg is a library for accessing a PostgreSQL database from the asyncio.
     * [motor](https://github.com/mongodb/motor) - The async Python driver for MongoDB.
-
+    
 ## Date and Time
 
 *Libraries for working with dates and times.*

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [aiomysql](https://github.com/aio-libs/aiomysql) - aiomysql is a library for accessing a MySQL database from the asyncio.
     * [aiopg](https://github.com/aio-libs/aiopg) - aiopg is a library for accessing a PostgreSQL database from the asyncio.
     * [motor](https://github.com/mongodb/motor) - The async Python driver for MongoDB.
-    
+
 ## Date and Time
 
 *Libraries for working with dates and times.*


### PR DESCRIPTION
## What is this Python project?
aiomysql is a "driver" for accessing a MySQL database from the [asyncio](http://docs.python.org/3.5/library/asyncio.html) (PEP-3156/tulip) framework. It depends on and reuses most parts of [PyMySQL](https://github.com/PyMySQL/PyMySQL) .

aiopg is a library for accessing a [PostgreSQL](http://www.postgresql.org/) database from the [asyncio](https://docs.python.org/3/library/asyncio.html) (PEP-3156/tulip) framework.

## What's the difference between this Python project and similar ones?

These db drivers operate asynchronously.
More details are as above.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
