### PR TITLE
Add Hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,6 +929,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [pip-tools](https://github.com/jazzband/pip-tools) - A set of tools to keep your pinned Python dependencies fresh.
     * [PyPI](https://pypi.org/)
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
+* [Hatch](https://github.com/ofek/hatch) - Modern, extensible Python project management.
 * [poetry](https://github.com/sdispater/poetry) - Python dependency management and packaging made easy.
 
 ## Package Repositories


### PR DESCRIPTION
## What is this Python project?

A tool for managing the entire lifecycle of a project: creation, versioning, building (with its build backend Hatchling), environment management, publishing, etc.

Note that Hatch will likely be adopted by PyPA in the next week so the repo location will change (I'll update the link when that happens):

- https://mail.python.org/archives/list/pypa-committers@python.org/thread/J2BL5XTTOCXUCELUE7L5P5HHJ7NXZGZ5/
- https://mail.python.org/archives/list/pypa-committers@python.org/thread/ZWSSNKQJ3GRIAK73FJS6KHOJNUJZYOVX/

## What's the difference between this Python project and similar ones?

- In comparison to `poetry`, Hatch specializes in environment management and has a more featureful plugin system.
- In comparison to `poetry-core`, Hatchling never strays from community standards and is in fact eager to adopt new ones (it's the only backend that currently supports [PEP 639](https://www.python.org/dev/peps/pep-0639/)).
- In comparison to `setuptools`, Hatchling is far smaller, making it less susceptible to security issues and more auditable. For example, the logic to build a wheel resides in this [one file](https://github.com/ofek/hatch/blob/master/backend/src/hatchling/builders/wheel.py). Also, wheels and sdists are built in a reproducible manner by default.
- In comparison to `flit-core`, Hatchling is extensible by design. For example, there is already [a plugin](https://github.com/ofek/hatch-vcs) for [setuptools_scm](https://github.com/pypa/setuptools_scm) (which despite the legacy naming is actually now decoupled from `setuptools`) and [a plugin](https://github.com/ofek/hatch-mypyc) for compiling code with [Mypyc](https://github.com/mypyc/mypyc).

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
