### PR TITLE
Add pybind11

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for providing foreign function interface.*
 
+* [pybind11](https://pybind11.readthedocs.io/en/stable/index.html) - Header-only Python wrapper for Modern C++11
 * [cffi](https://pypi.org/project/cffi/) - Foreign Function Interface for Python calling C code.
 * [ctypes](https://docs.python.org/3/library/ctypes.html) - (Python standard library) Foreign Function Interface for Python calling C code.
 * [PyCUDA](https://mathema.tician.de/software/pycuda/) - A Python wrapper for Nvidia's CUDA API.


### PR DESCRIPTION
## What is this Python project?

* pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code. (cite from the official doc)

* Inspired by Boost.Python, but aim to resolve the complexity.

* A very compact implementation. It's only composed of ~4K line without comments.

## What's the difference between this Python project and similar ones?

1. It's a lightweight, header only C++ library.
2. It supprots modern C++ (instead of just C)
3. One need not to learn a third language other than C++ and Python. (Some others require)
4. Also Used by popular project like Cafe2 machine learning framework.
5. Its documentation is quite complete!

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
