### PR TITLE
Add Flask-restx-boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     - [Web Frameworks](#web-frameworks)
     - [WebSocket](#websocket)
     - [WSGI Servers](#wsgi-servers)
+    - [Boilerplate](#Boilerplate)
 - [Resources](#resources)
     - [Books](#books)
     - [Newsletters](#newsletters)
@@ -1316,6 +1317,13 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [uWSGI](https://uwsgi-docs.readthedocs.io/en/latest/) - A project aims at developing a full stack for building hosting services, written in C.
 * [waitress](https://github.com/Pylons/waitress) - Multi-threaded, powers Pyramid.
 * [werkzeug](https://github.com/pallets/werkzeug) - A WSGI utility library for Python that powers Flask and can easily be embedded into your own projects.
+
+
+## Boilerplate
+
+*Boilerplate or code structure for python framework.*
+* [Flask Restx boilerplate](https://github.com/tranlyvu/Flask-RESTX-boilerplate) - Code base/boiler plate with restfull Flask-Restx framework.
+
 
 # Resources
 


### PR DESCRIPTION
## What is this Python project?

- Boilerplate /code structure for the restful Flask-Restx framework
- Link of [the project](https://github.com/tranlyvu/Flask-RESTX-boilerplate)

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
