### PR TITLE
Add wiki-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1282,6 +1282,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [pyspider](https://github.com/binux/pyspider) - A powerful spider system.
 * [robobrowser](https://github.com/jmcarp/robobrowser) - A simple, Pythonic library for browsing the web without a standalone web browser.
 * [scrapy](https://scrapy.org/) - A fast high-level screen scraping and web crawling framework.
+* [wiki-link](https://github.com/tranlyvu/wiki-link) - A multiprocessing web-scraping application to scrape the wiki pages.
 
 ## Web Frameworks
 


### PR DESCRIPTION
## What is this Python project?

wikilink is a multiprocessing web-scraping *application* to scrape the wiki pages, extract urls and find the minimum number of links between 2 given wiki pages.

https://github.com/tranlyvu/wiki-link

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
