### PR TITLE
Add moderngl

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Pygame](http://www.pygame.org/news.html) - Pygame is a set of Python modules designed for writing games.
 * [PyOgre](http://www.ogre3d.org/tikiwiki/PyOgre) - Python bindings for the Ogre 3D render engine, can be used for games, simulations, anything 3D.
 * [PyOpenGL](http://pyopengl.sourceforge.net/) - Python ctypes bindings for OpenGL and it's related APIs.
+* [ModernGL](https://github.com/moderngl/moderngl) - Modern Pythonic OpenGL bindings.
 * [PySDL2](https://pysdl2.readthedocs.io) - A ctypes based wrapper for the SDL2 library.
 * [RenPy](https://www.renpy.org/) - A Visual Novel engine.
 


### PR DESCRIPTION
## What is this Python project?

This project provides modern _pythonic_ bindings to OpenGL.

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

--Compared to PyOpenGL it is more pythonic, and easier to use and learn.
--Faster than PyOpenGL in certain cases.
--Less amount of code for the same behaviour.
```
# PyOpenGL
vbo1 = glGenBuffers(1)
GL.glBindBuffer(GL_ARRAY_BUFFER, vbo1)
GL.glBufferData(GL_ARRAY_BUFFER, b'Hello World!', GL_STATIC_DRAW)

vbo2 = glGenBuffers(1)
GL.glBindBuffer(GL_ARRAY_BUFFER, vbo2)
GL.glBufferData(GL_ARRAY_BUFFER, b'\x00' * 1024, GL_DYNAMIC_DRAW)
```
```
# ModernGL
vbo1 = ctx.buffer(b'Hello World!')
vbo2 = ctx.buffer(reserve=1024, dynamic=True)
```

Another pull request was made years ago here: #893 But it went stale. I'm actually surprised it isn't already on the list, it seems fairly popular, and quite nice.

Anyone who agrees with this pull request could submit an *Approve* review to it.
