### PR TITLE
Added frida-tools in debugger section

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [manhole](https://github.com/ionelmc/python-manhole) - Debugging UNIX socket connections and present the stacktraces for all threads and an interactive prompt.
     * [pyringe](https://github.com/google/pyringe) - Debugger capable of attaching to and injecting code into Python processes.
     * [python-hunter](https://github.com/ionelmc/python-hunter) - A flexible code tracing toolkit.
+    * [frida-tools](https://github.com/frida/frida-tools) - Cli tools for dynamic instrumentation toolkit for developers, reverse-engineers, and security researchers.
 * Profiler
     * [line_profiler](https://github.com/rkern/line_profiler) - Line-by-line profiling.
     * [memory_profiler](https://github.com/fabianp/memory_profiler) - Monitor Memory usage of Python code.


### PR DESCRIPTION
## What is this Python project?

Frida is a [free](https://www.gnu.org/philosophy/free-sw.en.html) dynamic instrumentation toolkit that enables software professionals to execute their own scripts in software that has traditionally been locked down; i.e. proprietary (such as Android applications).

This allows the software community to hook into live processes, enabling them to test, add functionality to, or even debug such applications.

from: https://techmonitor.ai/technology/software/frida-tool-software-reverse

“Frida makes it possible for a small company to create products compatible with products from large software companies. For example if a big company dominates the market in one area but isn’t interested in supporting users with Android phones, a small company could use Frida to gain the knowledge needed to create a compatible app for Android users.”

Due to its ability to hook into processes dynamically, developers can rapidly develop tools using Frida. For example, in an Android application process, this can be hooked into to extract the output of the process itself, meaning that any additional functionality can be added with minimal effort. (For the technically inclined, the Frida team has produced a [useful example](https://www.frida.re/docs/examples/android) for injecting arbitrary JavaScript into an Android app process.)

## What's the difference between this Python project and similar ones?

Frida though has cross platform compatibility stands out because of its ability to also debug android applications.
--

Anyone who agrees with this pull request could submit an *Approve* review to it.
