### PR TITLE
Update AWS Data Wrangler to AWS SDK for pandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for data analyzing.*
 
-* [AWS Data Wrangler](https://github.com/awslabs/aws-data-wrangler) - Pandas on AWS.
+* [AWS SDK for pandas](https://github.com/aws/aws-sdk-pandas) - Pandas on AWS.
 * [Blaze](https://github.com/blaze/blaze) - NumPy and Pandas interface to Big Data.
 * [Open Mining](https://github.com/mining/mining) - Business Intelligence (BI) in Pandas interface.
 * [Optimus](https://github.com/ironmussa/Optimus) - Agile Data Science Workflows made easy with PySpark.


### PR DESCRIPTION
## What is this Python project?

I am the maintainer of AWS Data Wrangler which has now been renamed to AWS SDK for pandas.

## What's the difference between this Python project and similar ones?

The former [URL](https://github.com/awslabs/aws-data-wrangler) is now pointing to the new [repository](https://github.com/aws/aws-sdk-pandas) with the new name 

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
