### PR TITLE
Add hyperparameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [configobj](https://github.com/DiffSK/configobj) - INI file parser with validation.
 * [configparser](https://docs.python.org/3/library/configparser.html) - (Python standard library) INI file parser.
 * [hydra](https://github.com/facebookresearch/hydra) - Hydra is a framework for elegantly configuring complex applications.
+* [hyperparameter](https://github.com/reiase/hyperparameter) - An elegant and lightweight configuration framework.
 * [profig](https://profig.readthedocs.io/en/latest/) - Config from multiple formats with value conversion.
 * [python-decouple](https://github.com/henriquebastos/python-decouple) - Strict separation of settings from code.
 


### PR DESCRIPTION
hyperparameter is a configuration framework designed for data scientists and machine learning engineers. It works in a more pythonic way:  the users write their code in python and add a decorator to the functions or classes; `hyperparameter` will map the keyword arguments to configuration keys and use a `with` context to manage the configurations.

## What is this Python project?

Describe features.

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
