### PR TITLE
Add mamba package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [PyPI](https://pypi.org/)
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [poetry](https://github.com/sdispater/poetry) - Python dependency management and packaging made easy.
+* [mamba](https://github.com/mamba-org/mamba) - The Fast Cross-Platform Package Manager.
+    * [micromamba](https://mamba.readthedocs.io/en/latest/installation.html#micromamba) - A tiny version of the mamba package manager.
 
 ## Package Repositories
 


### PR DESCRIPTION
## What is this Python project?

[mamba](https://github.com/mamba-org/mamba) is a reimplementation of the conda package manager in C++.

## What's the difference between this Python project and similar ones?

mamba is a full replacement for conda, on aarch64 Linux, the official conda may unavailable, mamba can be an alternative in this case.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
