### PR TITLE
Add strawberry-graphql to GraphQL Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for working with GraphQL.*
 
 * [graphene](https://github.com/graphql-python/graphene/) - GraphQL framework for Python.
+* [strawberry-graphql](https://github.com/strawberry-graphql/strawberry) - Python GraphQL library based on dataclasses and type annotations 🍓
 * [tartiflette-aiohttp](https://github.com/tartiflette/tartiflette-aiohttp/) - An `aiohttp`-based wrapper for Tartiflette to expose GraphQL APIs over HTTP.
 * [tartiflette-asgi](https://github.com/tartiflette/tartiflette-asgi/) - ASGI support for the Tartiflette GraphQL engine.
 * [tartiflette](https://tartiflette.io) - SDL-first GraphQL engine implementation for Python 3.6+ and asyncio.

--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Libraries for working with GraphQL.*
 
 * [graphene](https://github.com/graphql-python/graphene/) - GraphQL framework for Python.
-* [strawberry-graphql](https://github.com/strawberry-graphql/strawberry) - Python GraphQL library based on dataclasses and type annotations 🍓
+* [strawberry-graphql](https://github.com/strawberry-graphql/strawberry) - Python GraphQL library based on dataclasses 🍓
 * [tartiflette-aiohttp](https://github.com/tartiflette/tartiflette-aiohttp/) - An `aiohttp`-based wrapper for Tartiflette to expose GraphQL APIs over HTTP.
 * [tartiflette-asgi](https://github.com/tartiflette/tartiflette-asgi/) - ASGI support for the Tartiflette GraphQL engine.
 * [tartiflette](https://tartiflette.io) - SDL-first GraphQL engine implementation for Python 3.6+ and asyncio.


### PR DESCRIPTION
## What is this Python project?

[website](https://strawberry.rocks/)
Python GraphQL library inspired by dataclasses


## What's the difference between this Python project and similar ones?
Compared to Graphene
Works with type annotations, has a better developer experience and is active mantained. 
Strawberry works with Django, asgi, Starlette, FastAPI, Flask and other frameworks. 

As [FastAPI docs](https://fastapi.tiangolo.com/advanced/graphql/) says: 
>If you need or want to work with GraphQL, [Strawberry](https://strawberry.rocks/) is the recommended library as it has the design closest to FastAPI's design, it's all based on type annotations.
--

Anyone who agrees with this pull request could submit an *Approve* review to it.
