### PR TITLE
Add Learn Python 3 Open Source Book

### DIFF
--- a/README.md
+++ b/README.md
@@ -1325,6 +1325,7 @@ Where to discover learning resources or new Python libraries.
 
 - [Fluent Python](https://www.oreilly.com/library/view/fluent-python/9781491946237/)
 - [Think Python](https://greenteapress.com/wp/think-python-2e/)
+- [Learn Python 3](https://github.com/animator/learn-python)
 
 ## Websites
 


### PR DESCRIPTION
## What is this Python project?

**Learn Python 3** is an open source book to learn Python Programming. 
It resides in [Github](https://github.com/animator/learn-python) and is available both as [PDF](https://github.com/animator/learn-python/blob/main/pdf/learn-python-v2022.10.pdf) and [HTML](https://animator.github.io/learn-python/).

## What's the difference between this Python project and similar ones?

The book has a very well defined structure. It is concise and touches a lot of fundamental concepts very well.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
