### PR TITLE
Add click-extra.

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Command-line Application Development
     * [cement](http://builtoncement.com/) - CLI Application Framework for Python.
     * [click](http://click.pocoo.org/dev/) - A package for creating beautiful command line interfaces in a composable way.
+    * [click-extra](https://github.com/kdeldycke/click-extra/) - A drop-in replacement for `click` which adds colorization, configuration loading and missing features.
     * [cliff](https://docs.openstack.org/developer/cliff/) - A framework for creating command-line programs with multi-level commands.
     * [docopt](http://docopt.org/) - Pythonic command line arguments parser.
     * [python-fire](https://github.com/google/python-fire) - A library for creating command line interfaces from absolutely any Python object.


### PR DESCRIPTION
## What is this Python project?

[`click-extra`](https://github.com/kdeldycke/click-extra) is a collection of helpers and utilities for [Click](https://click.palletsprojects.com/), the Python CLI framework.

It is a drop-in replacement with good defaults that saves lots of boilerplate code and frustration. It also comes with [workarounds and patches](https://kdeldycke.github.io/click-extra/issues.html) that have not reached upstream yet (or are unlikely to).

## What's the difference between this Python project and similar ones?

This project adds the following features on top of `click`:

- Configuration file loader for:
  - `TOML`
  - `YAML`
  - `JSON`, with inline and block comments (Python-style `#` and Javascript-style `//`)
  - `INI`, with extended interpolation, multi-level sections and non-native types (`list`, `set`, …)
  - `XML`
- Download configuration from remote URLs
- Optional strict validation of configuration
- Search of configuration file from default user folder and glob patterns
- Respect of `CLI` > `Configuration` > `Environment` > `Defaults` precedence
- `--show-params` option to debug parameters defaults, values, environment variables and provenance
- Colorization of help screens
- `-h`/`--help` option names (see [rant on other inconsistencies](https://blog.craftyguy.net/cmdline-help/))
- `--color`/`--no-color` option flag
- Recognize the `NO_COLOR` environment variable convention from [`no-color.org`](https://no-color.org)
- Colored `--version` option
- Colored `--verbosity` option and logs
- `--time`/`--no-time` flag to measure duration of command execution
- Platform recognition utilities (macOS, Linux and Windows)
- New conditional markers for `pytest`:
  - `@skip_linux`, `@skip_macos` and `@skip_windows`
  - `@unless_linux`, `@unless_macos` and `@unless_windows`
  - `@destructive` and `@non_destructive`
- [ANSI-capable Pygments lexers](https://kdeldycke.github.io/click-extra/pygments.html#lexers) for shell session and console output
- Pygments styles and filters for ANSI rendering
- [Fixes 30+ bugs](https://kdeldycke.github.io/click-extra/issues.html) from other Click-related projects
- Rely on [`cloup`](https://github.com/janluke/cloup) to add:
  - option groups
  - constraints
  - subcommands sections
  - aliases
  - command suggestion (`Did you mean <subcommand>?`)

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
