### PR TITLE
Add tackle in productivity tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [Invoke](https://github.com/pyinvoke/invoke#readme) - A tool for managing shell-oriented subprocesses and organizing executable Python code into CLI-invokable tasks.
     * [PathPicker](https://github.com/facebook/PathPicker) - Select files out of bash output.
     * [percol](https://github.com/mooz/percol) - Adds flavor of interactive selection to the traditional pipe concept on UNIX.
+    * [tackle](https://github.com/sudoblockio/tackle) - A general purpose configuration language to build modular code generators and declarative CLIs.
     * [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
     * [tmuxp](https://github.com/tony/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.
     * [try](https://github.com/timofurrer/try) - A dead simple CLI to try out python packages - it's never been easier.


### PR DESCRIPTION
## What is this Python project?

A rewrite of [cookiecutter](https://github.com/audreyr/cookiecutter) into a general purpose configuration language to build modular code generators and declarative CLIs.

[tackle](https://github.com/sudoblockio/tackle)

## What's the difference between this Python project and similar ones?

- Does everything cookiecutter does plus the following
- Creates self documenting CLIs out of yaml / json / toml 
- Allows users to modularize code templating by importing other tackle providers that specialize in various parts of generating code 
- Turing complete syntax lets users conditionally prompt for options 
- >100 hooks which act as plugins within your config file 

It is most comparable to Dhall, jsonnet, and CUE but specializes in generating code. I personally use it to manage kubernetes manifests by code generating them sort of like Helm but much more flexible. 

---

Anyone who agrees with this pull request could submit an *Approve* review to it.
