### PR TITLE
Add sqlmodel to ORMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,6 +915,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [peewee](https://github.com/coleifer/peewee) - A small, expressive ORM.
     * [pony](https://github.com/ponyorm/pony/) - ORM that provides a generator-oriented interface to SQL.
     * [pydal](https://github.com/web2py/pydal/) - A pure Python Database Abstraction Layer.
+    * [sqlmodel](https://github.com/tiangolo/sqlmodel) - A wrapper of [SQLAlchemy](https://www.sqlalchemy.org/) based on [pydantic](https://github.com/pydantic/pydantic) objects.
 * NoSQL Databases
     * [hot-redis](https://github.com/stephenmcd/hot-redis) - Rich Python data types for Redis.
     * [mongoengine](https://github.com/MongoEngine/mongoengine) - A Python Object-Document-Mapper for working with MongoDB.


### PR DESCRIPTION
## What is this Python project?

A wrapper of [SQLAlchemy](https://www.sqlalchemy.org/) based on [pydantic](https://github.com/pydantic/pydantic) objects. Made by tiangelo, creator of FastAPI.

## What's the difference between this Python project and similar ones?

From docs: 

Intuitive to write: Great editor support. Completion everywhere. Less time debugging. Designed to be easy to use and learn. Less time reading docs.
Easy to use: It has sensible defaults and does a lot of work underneath to simplify the code you write.
Compatible: It is designed to be compatible with FastAPI, Pydantic, and SQLAlchemy.
Extensible: You have all the power of SQLAlchemy and Pydantic underneath.
Short: Minimize code duplication. A single type annotation does a lot of work. No need to duplicate models in SQLAlchemy and Pydantic.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
