### PR TITLE
Add typer to Command-line Interface Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [docopt](http://docopt.org/) - Pythonic command line arguments parser.
     * [python-fire](https://github.com/google/python-fire) - A library for creating command line interfaces from absolutely any Python object.
     * [python-prompt-toolkit](https://github.com/jonathanslenders/python-prompt-toolkit) - A library for building powerful interactive command lines.
+    * [typer](https://github.com/tiangolo/typer) - A library for building CLI applications based on Python 3.6+ type hints.
 * Terminal Rendering
     * [alive-progress](https://github.com/rsalmei/alive-progress) - A new kind of Progress Bar, with real-time throughput, eta and very cool animations.
     * [asciimatics](https://github.com/peterbrittain/asciimatics) - A package to create full-screen text UIs (from interactive forms to ASCII animations).


### PR DESCRIPTION
## What is this Python project?

A library for building CLI applications based on Python 3.6+ type hints. Made by tiangelo, the creator of fastapi 

[typer](https://github.com/tiangolo/typer)

## What's the difference between this Python project and similar ones?

From readme: 

Intuitive to write: Great editor support. Completion everywhere. Less time debugging. Designed to be easy to use and learn. Less time reading docs.
Easy to use: It's easy to use for the final users. Automatic help, and automatic completion for all shells.
Short: Minimize code duplication. Multiple features from each parameter declaration. Fewer bugs.
Start simple: The simplest example adds only 2 lines of code to your app: 1 import, 1 function call.
Grow large: Grow in complexity as much as you want, create arbitrarily complex trees of commands and groups of subcommands, with options and arguments.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
