### PR TITLE
Add csv and tomllib libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,9 +1103,12 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * YAML
     * [PyYAML](http://pyyaml.org/) - YAML implementations for Python.
 * CSV
+    * [csv](https://docs.python.org/3/library/csv.html) - (Python standard libray) Read and write tabular data in CSV format.
     * [csvkit](https://github.com/wireservice/csvkit) - Utilities for converting to and working with CSV.
 * Archive
     * [unp](https://github.com/mitsuhiko/unp) - A command line tool that can unpack archives easily.
+* TOML
+    * [tomllib](https://docs.python.org/3/library/tomllib.html) - (Python standard library) Provides an interface for parsing TOML
 
 ## Static Site Generator
 


### PR DESCRIPTION
## What is this Python project?

Python Standard Library for parsing csv and TOML files

## What's the difference between this Python project and similar ones?

No real difference to make here, just thought it was right to include the standard library. 

`csv` isn't in the list while `csvkit` is. And `tomllib` was recently released with python 3.11.

Anyone who agrees with this pull request could submit an *Approve* review to it.
