### PR TITLE
Add mashumaro to Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,6 +1063,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [pysimdjson](https://github.com/TkTech/pysimdjson) - A Python bindings for [simdjson](https://github.com/lemire/simdjson).
 * [python-rapidjson](https://github.com/python-rapidjson/python-rapidjson) - A Python wrapper around [RapidJSON](https://github.com/Tencent/rapidjson).
 * [ultrajson](https://github.com/esnme/ultrajson) - A fast JSON decoder and encoder written in C with Python bindings.
+* [mashumaro](https://github.com/Fatal1ty/mashumaro) - Fast and well tested serialization framework on top of dataclasses
 
 ## Serverless Frameworks
 


### PR DESCRIPTION
## What is this Python project?

This project adds ability to generate methods for serialization / deserialization of dataclasses with big variety of standard types out of the box to / from different formats (dict, json, msgpack, yaml, toml).

## What's the difference between this Python project and similar ones?

* it's written in pure python and works by highly optimized code generation, which makes it faster compared to alternatives
* it has many extension options (third-party types, hooks, different serialization strategies, dialects, aliases, etc.)
* it has full support for user-defined generic types
* it has full support for user-defined variadic generic types from [PEP 646](https://peps.python.org/pep-0646/)

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
