### PR TITLE
Add link to python roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     - [WebSocket](#websocket)
     - [WSGI Servers](#wsgi-servers)
 - [Resources](#resources)
+    - [Roadmaps](#roadmaps)
     - [Books](#books)
     - [Newsletters](#newsletters)
     - [Podcasts](#podcasts)
@@ -1319,6 +1320,10 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 # Resources
 
 Where to discover learning resources or new Python libraries.
+
+## Roadmaps
+
+- [Python Roadmap](https://roadmap.sh/python)
 
 ## Books
 


### PR DESCRIPTION
## What is this Python project?

[roadmap.sh](https://roadmap.sh) is an opensource project with community curated roadmaps and visual guides for developers. Linked resource is the roadmap for learning Python.

## What's the difference between this Python project and similar ones?

There is any other similar roadmap in the list.
