### PR TITLE
Add ruff code linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [pylama](https://github.com/klen/pylama) - A code audit tool for Python and JavaScript.
     * [pylint](https://www.pylint.org/) - A fully customizable source code analyzer.
     * [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) - The strictest and most opinionated python linter ever.
+    * [ruff](https://beta.ruff.rs/docs/) - An extremely fast Python linter, written in Rust.
 * Code Formatters
     * [black](https://github.com/python/black) - The uncompromising Python code formatter.
     * [isort](https://github.com/timothycrosley/isort) - A Python utility / library to sort imports.


### PR DESCRIPTION
## What is this Python project?

An extremely fast Python linter, written in Rust.

## What's the difference between this Python project and similar ones?
    * 10-100x faster than existing linters

    * Installable via pip

    *  pyproject.toml support

    *  Built-in caching, to avoid re-analyzing unchanged files

    * Autofix support, for automatic error correction (e.g., automatically remove unused imports)

    * [Near-parity](https://beta.ruff.rs/docs/#how-does-ruff-compare-to-flake8) with the built-in Flake8 rule set

    * Native re-implementations of dozens of Flake8 plugins, like [flake8-bugbear](https://pypi.org/project/flake8-bugbear/)

    *  First-party editor integrations for [VS Code](https://github.com/charliermarsh/ruff-vscode) and [more](https://github.com/charliermarsh/ruff-lsp)

    *  Monorepo-friendly, with [hierarchical and cascading configuration](https://beta.ruff.rs/docs/#pyprojecttoml-discovery)

Ruff aims to be orders of magnitude faster than alternative tools while integrating more functionality behind a single, common interface.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
