### PR TITLE
Add pyodbc

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Other Relational Databases
     * [pymssql](https://pymssql.readthedocs.io/en/latest/) - A simple database interface to Microsoft SQL Server.
     * [clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver) - Python driver with native interface for ClickHouse.
+    * [pyodbc](https://github.com/mkleehammer/pyodbc) - An open source Python module that makes accessing ODBC databases simple.
 * NoSQL Databases
     * [cassandra-driver](https://github.com/datastax/python-driver) - The Python Driver for Apache Cassandra.
     * [happybase](https://github.com/wbolster/happybase) - A developer-friendly library for Apache HBase.


### PR DESCRIPTION
## What is this Python project?

pyodbc is an open-source Python module that makes accessing ODBC databases simple. It implements the DB API 2.0 specification but is packed with even more Pythonic convenience.

## What's the difference between this Python project and similar ones?

It's the only well-maintained open-source python module that allows connecting to all kinds of persistent storage with support for ODBC like Microsoft Access, Microsoft Excel, Google Big Query, Teradata, Vertica, Hive, and more.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
