### PR TITLE
Add python-benedict

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Box](https://github.com/cdgriffith/Box) - Python dictionaries with advanced dot notation access.
 * [dataclasses](https://docs.python.org/3/library/dataclasses.html) - (Python standard library) Data classes.
 * [DottedDict](https://github.com/carlosescri/DottedDict) - A library that provides a method of accessing lists and dicts with a dotted path notation.
+* [python-benedict](https://github.com/fabiocaccamo/python-benedict) - A dict subclass with keylist/keypath support, built-in I/O operations (base64, csv, ini, json, pickle, plist, query-string, toml, xls, xml, yaml), s3 support and many utilities.
 
 ## CMS
 


### PR DESCRIPTION
## What is this Python project?

`python-benedict` is a subclass of the built-in dict type, meaning that it is fully compatible with existing dictionaries and can be used as a drop-in replacement in most cases.

### Features
-   100% **backward-compatible**, you can safely wrap existing dictionaries.
-   **Keylist** support using **list of keys** as key.
-   **Keypath** support using **keypath-separator** *(dot syntax by default)*.
-   Keypath **list-index** support  *(also negative)* using the standard `[n]` suffix.
-   Normalized **I/O operations** with most common formats: `base64`, `csv`, `ini`, `json`, `pickle`, `plist`, `query-string`, `toml`, `xls`, `xml`, `yaml`.
-   Multiple **I/O operations** backends: `filepath` *(read/write)*, `url` *(read-only)*, `s3` *(read/write)*.
-   Many **utility** and **parse methods** to retrieve data as needed *(check the [API](https://github.com/fabiocaccamo/python-benedict#api) section)*.
-   Well **tested**. ;)

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
