### PR TITLE
Fixed Zappa link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,7 +1069,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Frameworks for developing serverless Python code.*
 
 * [python-lambda](https://github.com/nficano/python-lambda) - A toolkit for developing and deploying Python code in AWS Lambda.
-* [Zappa](https://github.com/Miserlou/Zappa) - A tool for deploying WSGI applications on AWS Lambda and API Gateway.
+* [Zappa](https://github.com/zappa/Zappa) - A tool for deploying WSGI applications on AWS Lambda and API Gateway.
 
 ## Shell
 


### PR DESCRIPTION
Fixed Zappa github project link as it moved to a new repository under https://github.com/zappa/Zappa

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
