### PR TITLE
Fix pypdf description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [xlwt](https://github.com/python-excel/xlwt) / [xlrd](https://github.com/python-excel/xlrd) - Writing and reading data and formatting information from Excel files.
 * PDF
     * [PDFMiner](https://github.com/euske/pdfminer) - A tool for extracting information from PDF documents.
-    * [PyPDF2](https://github.com/mstamy2/PyPDF2) - A library capable of splitting, merging and transforming PDF pages.
+    * [pypdf](https://pypi.org/project/pypdf/) - A library capable of splitting, merging and transforming PDF pages.
     * [ReportLab](https://www.reportlab.com/opensource/) - Allowing Rapid creation of rich PDF documents.
 * Markdown
     * [Mistune](https://github.com/lepture/mistune) - Fastest and full featured pure Python parsers of Markdown.


### PR DESCRIPTION
* PyPDF2 was merged into pypdf and PyPDF2 got deprecated: https://pypi.org/project/PyPDF2/
* Link to PyPI instead of the (moved) Github project
* pypdf==3.1.0 is essentially the same as PyPDF2==3.0.0, except for the name
* I (Martin Thoma) am the maintainer of both projects