### PR TITLE
Update Pyqt and add PySide README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,7 +671,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [kivy](https://kivy.org/) - A library for creating NUI applications, running on Windows, Linux, Mac OS X, Android and iOS.
 * [pyglet](https://github.com/pyglet/pyglet) - A cross-platform windowing and multimedia library for Python.
 * [PyGObject](https://wiki.gnome.org/Projects/PyGObject) - Python Bindings for GLib/GObject/GIO/GTK+ (GTK+3).
-* [PyQt](https://doc.qt.io/qtforpython/) - Python bindings for the [Qt](https://www.qt.io/) cross-platform application and UI framework.
+* [PySide](https://doc.qt.io/qtforpython/) - Python bindings for the [Qt](https://www.qt.io/) cross-platform application and UI framework.
+* [PyQt](https://riverbankcomputing.com/software/pyqt/) - Python bindings for the [Qt](https://www.qt.io/) cross-platform application and UI framework.
 * [PySimpleGUI](https://github.com/PySimpleGUI/PySimpleGUI) - Wrapper for tkinter, Qt, WxPython and Remi.
 * [pywebview](https://github.com/r0x0r/pywebview/) - A lightweight cross-platform native wrapper around a webview component.
 * [Tkinter](https://wiki.python.org/moin/TkInter) - Tkinter is Python's de-facto standard GUI package.


### PR DESCRIPTION
Update Pyqt and add PySide

## PyQT vs PySide

PyQt and PySide are two sets of Python bindings for the Qt toolkit by The Qt Company, used for developing graphical user interface (GUI) applications. Both are very similar in terms of functionality and design, as they both provide Python bindings for the same Qt libraries. However, there are some differences between them that are detailed below:

License: PyQt has a commercial license, which means a license is required for commercial use. PySide, on the other hand, is open-source and distributed under the terms of the GNU General Public License (GPL).

Support: PyQt is maintained and developed by Riverbank Computing Ltd., while PySide is developed and maintained by the open-source community and The Qt Company.

Versions: PyQt has support for older versions of Qt, while PySide only has support for more recent versions.

Documentation: PyQt has more detailed and extensive documentation compared to PySide.

Overall, both tools are excellent choices for developing GUI applications in Python. The choice between PyQt and PySide will depend on the project's needs, personal preference, and budget.
