### PR TITLE
remove mrq

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,7 +1131,6 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [celery](https://docs.celeryproject.org/en/stable/) - An asynchronous task queue/job queue based on distributed message passing.
 * [dramatiq](https://github.com/Bogdanp/dramatiq) - A fast and reliable background task processing library for Python 3.
 * [huey](https://github.com/coleifer/huey) - Little multi-threaded task queue.
-* [mrq](https://github.com/pricingassistant/mrq) - A distributed worker task queue in Python using Redis & gevent.
 * [rq](https://github.com/rq/rq) - Simple job queues for Python.
 
 ## Template Engine


### PR DESCRIPTION
Unmaintained. Last release in 2018, commit in 2020.
extra-malus : has ~ 1/4 of the forks and stars of the other projects of its category.
