### PR TITLE
Add pyi18n by sectasy0

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for working with i18n.*
 
+* [pyi18n](https://github.com/sectasy0/pyi18n) - GNU gettext free, simple and easy to use internationalization library for Python, inspired by Ruby i18n.
 * [Babel](http://babel.pocoo.org/en/latest/) - An internationalization library for Python.
 * [PyICU](https://github.com/ovalhub/pyicu) - A wrapper of International Components for Unicode C++ library ([ICU](http://site.icu-project.org/)).
 


### PR DESCRIPTION
## What is this Python project?

PyI18n is GNU gettext free, simple and easy to use internationalization library for Python, inspired by Ruby i18n. It supposed to be lightweight and fast all the time.

## What's the difference between this Python project and similar ones?

- It is simple and easy to use, supports namespaces as well.
- Does not require any additional dependencies other than PyYAML.
- Actively supported and developed, all bugs are fixed as soon as possible.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
