### PR TITLE
Remove zipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,7 +1045,6 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [SimPy](https://gitlab.com/team-simpy/simpy) -  A process-based discrete-event simulation framework.
 * [statsmodels](https://github.com/statsmodels/statsmodels) - Statistical modeling and econometrics in Python.
 * [SymPy](https://github.com/sympy/sympy) - A Python library for symbolic mathematics.
-* [Zipline](https://github.com/quantopian/zipline) - A Pythonic algorithmic trading library.
 
 ## Search
 


### PR DESCRIPTION
Zipline is no longer maintained (see https://github.com/quantopian/zipline/issues/2841).

Either remove or replace with a maintained fork.