### PR TITLE
Add mamba cross platform package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,6 +931,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [PyPI](https://pypi.org/)
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [poetry](https://github.com/sdispater/poetry) - Python dependency management and packaging made easy.
+* [mamba](https://mamba.readthedocs.io/) - Mamba is a fast, robust, and cross-platform package manager.
+
 
 ## Package Repositories
 


### PR DESCRIPTION
## What is this Python project?
Mamba is a fast, robust, and cross-platform package manager.

Describe features.
It runs on Windows, OS X and Linux (ARM64 and PPC64LE included) and is fully compatible with conda packages and supports most of conda’s commands.

## What's the difference between this Python project and similar ones?
The mamba-org organization hosts multiple Mamba flavors:

mamba: a Python-based CLI conceived as a drop-in replacement for conda, offering higher speed and more reliable environment solutions

micromamba: a pure C++-based CLI, self-contained in a single-file executable

libmamba: a C++ library exposing low-level and high-level APIs on top of which both mamba and micromamba are built

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
