### PR TITLE
Add PDM to Package Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,7 +931,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [PyPI](https://pypi.org/)
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [poetry](https://github.com/sdispater/poetry) - Python dependency management and packaging made easy.
-* [PDM](https://pdm.fming.dev/latest/) - A modern Python package and dependency manager supporting the latest PEP standards.
+* [PDM](https://pdm-project.org/latest/) - A modern Python package and dependency manager supporting the latest PEP standards.
 
 ## Package Repositories
 

--- a/README.md
+++ b/README.md
@@ -931,6 +931,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [PyPI](https://pypi.org/)
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [poetry](https://github.com/sdispater/poetry) - Python dependency management and packaging made easy.
+* [PDM](https://pdm.fming.dev/latest/) - A modern Python package and dependency manager supporting the latest PEP standards.
 
 ## Package Repositories
 


### PR DESCRIPTION
## What is this Python project?

[PDM](https://pdm.fming.dev/latest/) is a modern Python package and dependency manager supporting the latest PEP standards. But it is more than a package manager. It boosts your development workflow in various aspects. The most significant benefit is it installs and manages packages in a similar way to npm that doesn't need to create a virtualenv at all!

Feature highlights:

- Simple and fast dependency resolver, mainly for large binary distributions.
- A [PEP 517](https://www.python.org/dev/peps/pep-0517) build backend.
- [PEP 621](https://www.python.org/dev/peps/pep-0621) project metadata.
- Flexible and powerful plug-in system.
- Versatile user scripts.
- Opt-in centralized installation cache like [pnpm](https://pnpm.io/motivation#saving-disk-space-and-boosting-installation-speed).

## What's the difference between this Python project and similar ones?

PDM is like Poetry, but more respectful of PEP standards, with more features.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
