### PR TITLE
add sharded-queue library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [huey](https://github.com/coleifer/huey) - Little multi-threaded task queue.
 * [mrq](https://github.com/pricingassistant/mrq) - A distributed worker task queue in Python using Redis & gevent.
 * [rq](https://github.com/rq/rq) - Simple job queues for Python.
+* [sharded-queue](https://github.com/basis-company/sharded-queue.py) - Sharded-queue is a queue with sub-queues and strict order.
 
 ## Template Engine
 


### PR DESCRIPTION
## What is this Python project?

Imagine your job queue operates at very high rps and needs distribution over multiple workers. But you need to keep context-sensitive requests in same thread and manage thread request processing priority. In other words, sharded queue is a queue with sub-queues inside. Tasks are executed in FIFO order and you define how to route them correctly per handler basis.

## What's the difference between this Python project and similar ones?

There are no libraries that can be used for sharding and prioritize job queues keeping strict order

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
