### PR TITLE
Updated psycopg2's homepage link and possibly a new project related to psycopg2

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [mysqlclient](https://github.com/PyMySQL/mysqlclient-python) - MySQL connector with Python 3 support ([mysql-python](https://sourceforge.net/projects/mysql-python/) fork).
     * [PyMySQL](https://github.com/PyMySQL/PyMySQL) - A pure Python MySQL driver compatible to mysql-python.
 * PostgreSQL - [awesome-postgres](https://github.com/dhamaniasad/awesome-postgres)
-    * [psycopg2](http://initd.org/psycopg/) - The most popular PostgreSQL adapter for Python.
+    * [psycopg2](https://www.psycopg.org) - The most popular PostgreSQL adapter for Python.
     * [queries](https://github.com/gmr/queries) - A wrapper of the psycopg2 library for interacting with PostgreSQL.
 * SQlite - [awesome-sqlite](https://github.com/planetopendata/awesome-sqlite)
     * [sqlite3](https://docs.python.org/3/library/sqlite3.html) - (Python standard library) SQlite interface compliant with DB-API 2.0


### PR DESCRIPTION
## What is this Python project?

I updated the homepage link for psycopg2, that was not working previously.

## What's the difference between this Python project and similar ones?

I discovered that psycopg now has version 3. Could psycopg3 be added as a new project?

Some new features from psycopg3 compared to psycopg2
- Asynchronous support
- Server-side parameters binding
- Prepared statements

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
