### PR TITLE
Add FastStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Stream Processing
     * [faust](https://github.com/robinhood/faust) - A stream processing library, porting the ideas from [Kafka Streams](https://kafka.apache.org/documentation/streams/) to Python.
     * [streamparse](https://github.com/Parsely/streamparse) - Run Python code against real-time streams of data via [Apache Storm](http://storm.apache.org/).
-    * [FastStream](https://github.com/airtai/faststream) - All in one stream processing framework using [Kafka Streams](https://kafka.apache.org/documentation/streams/) or [RabbitMQ](https://www.rabbitmq.com/).
+    * [FastStream](https://github.com/airtai/faststream) - All in one stream processing framework currently supporting [Kafka](https://kafka.apache.org/) or [RabbitMQ](https://www.rabbitmq.com/).
 
 ## Distribution
 

--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Stream Processing
     * [faust](https://github.com/robinhood/faust) - A stream processing library, porting the ideas from [Kafka Streams](https://kafka.apache.org/documentation/streams/) to Python.
     * [streamparse](https://github.com/Parsely/streamparse) - Run Python code against real-time streams of data via [Apache Storm](http://storm.apache.org/).
+    * [FastStream](https://github.com/airtai/faststream) - All in one stream processing framework using [Kafka Streams](https://kafka.apache.org/documentation/streams/) or [RabbitMQ](https://www.rabbitmq.com/).
 
 ## Distribution
 


### PR DESCRIPTION
## What is this Python project?

FastStream is a project that simplifies the process of writing producers and consumers for different message brokers.
It's currently supporting Apache and Kafka only, but there are other brokers that will be implemented in a future.

## What's the difference between this Python project and similar ones?

FastStream is automated.
It automatically handles networking, validating, parsing and docs creation.
It's also fully compatible with any HTTP framework.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
