### PR TITLE
Replace gym with Gymnasium

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,7 +836,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries for Machine Learning. Also see [awesome-machine-learning](https://github.com/josephmisiti/awesome-machine-learning#python).*
 
-* [gym](https://github.com/openai/gym) - A toolkit for developing and comparing reinforcement learning algorithms.
+* [Gymnasium](https://github.com/Farama-Foundation/Gymnasium) - A library for developing and comparing reinforcement learning algorithms (successor of [gym](https://github.com/openai/gym).
 * [H2O](https://github.com/h2oai/h2o-3) - Open Source Fast Scalable Machine Learning Platform.
 * [Metrics](https://github.com/benhamner/Metrics) - Machine learning evaluation metrics.
 * [NuPIC](https://github.com/numenta/nupic) - Numenta Platform for Intelligent Computing.


### PR DESCRIPTION
## What is this Python project?

[Gymnasium](https://github.com/Farama-Foundation/Gymnasium) is the successor of [gym](https://github.com/openai/gym), later of which is no longer being maintained.

## What's the difference between this Python project and similar ones?

Just the fact that [gym](https://github.com/openai/gym) is no longer maintained and all further developments and fixes will only happen in [Gymnasium](https://github.com/Farama-Foundation/Gymnasium) should be enough to validate this change.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
