### PR TITLE
Add pyTermTk

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [PyGObject](https://wiki.gnome.org/Projects/PyGObject) - Python Bindings for GLib/GObject/GIO/GTK+ (GTK+3).
 * [PyQt](https://doc.qt.io/qtforpython/) - Python bindings for the [Qt](https://www.qt.io/) cross-platform application and UI framework.
 * [PySimpleGUI](https://github.com/PySimpleGUI/PySimpleGUI) - Wrapper for tkinter, Qt, WxPython and Remi.
+* [pyTermTk](https://github.com/ceccopierangiolieugenio/pyTermTk) - Self contained Terminal UI library for Linux,Windows,MacOS,HTML5
 * [pywebview](https://github.com/r0x0r/pywebview/) - A lightweight cross-platform native wrapper around a webview component.
 * [Tkinter](https://wiki.python.org/moin/TkInter) - Tkinter is Python's de-facto standard GUI package.
 * [Toga](https://github.com/pybee/toga) - A Python native, OS native GUI toolkit.


### PR DESCRIPTION
## What is this Python project?

pyTermTk is a self contained TUI library in a qt/tkinter api style cross compatible and with many built in widgets, i.e.:

https://github.com/vinta/awesome-python/assets/8876552/52e77f6d-e0cf-49d3-b134-bf1b310f297b

## What's the difference between this Python project and similar ones?

So far I didn't find any similar project,
Textual is a close one but I am not sure you can build this kind of UI using textual:

https://github.com/vinta/awesome-python/assets/8876552/a5af4989-ca1a-4d04-8164-0b02362c090e

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
