### PR TITLE
Fixed a Number of Dead Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Compile software from source code.*
 
-* [BitBake](http://www.yoctoproject.org/docs/1.6/bitbake-user-manual/bitbake-user-manual.html) - A make-like build tool for embedded Linux.
+* [BitBake](https://docs.yoctoproject.org/bitbake/2.4/index.html) - A make-like build tool for embedded Linux.
 * [buildout](http://www.buildout.org/en/latest/) - A build system for creating, assembling and deploying applications from multiple parts.
 * [PlatformIO](https://github.com/platformio/platformio-core) - A console tool to build code with different development platforms.
 * [pybuilder](https://github.com/pybuilder/pybuilder) - A continuous build tool written in pure Python.
@@ -412,7 +412,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [mysqlclient](https://github.com/PyMySQL/mysqlclient-python) - MySQL connector with Python 3 support ([mysql-python](https://sourceforge.net/projects/mysql-python/) fork).
     * [PyMySQL](https://github.com/PyMySQL/PyMySQL) - A pure Python MySQL driver compatible to mysql-python.
 * PostgreSQL - [awesome-postgres](https://github.com/dhamaniasad/awesome-postgres)
-    * [psycopg2](http://initd.org/psycopg/) - The most popular PostgreSQL adapter for Python.
+    * [psycopg](https://www.psycopg.org/) - The most popular PostgreSQL adapter for Python.
     * [queries](https://github.com/gmr/queries) - A wrapper of the psycopg2 library for interacting with PostgreSQL.
 * SQlite - [awesome-sqlite](https://github.com/planetopendata/awesome-sqlite)
     * [sqlite3](https://docs.python.org/3/library/sqlite3.html) - (Python standard library) SQlite interface compliant with DB-API 2.0
@@ -424,7 +424,6 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [cassandra-driver](https://github.com/datastax/python-driver) - The Python Driver for Apache Cassandra.
     * [happybase](https://github.com/wbolster/happybase) - A developer-friendly library for Apache HBase.
     * [kafka-python](https://github.com/dpkp/kafka-python) - The Python client for Apache Kafka.
-    * [py2neo](https://py2neo.org/) - A client library and toolkit for working with Neo4j.
     * [pymongo](https://github.com/mongodb/mongo-python-driver) - The official Python client for MongoDB.
     * [redis-py](https://github.com/andymccurdy/redis-py) - The Python client for Redis.
 * Asynchronous Clients
@@ -568,7 +567,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [money](https://github.com/carlospalol/money) - `Money` class with optional CLDR-backed locale-aware formatting and an extensible currency exchange.
 * [python-currencies](https://github.com/Alir3z4/python-currencies) - Display money format and its filthy currencies.
 * [saleor](https://saleor.io/) - Headless open-source e-commerce platform.
-* [shoop](https://www.shuup.com/en/) - An open source E-Commerce platform based on Django.
+* [shoop](https://www.shuup.com/) - An open source E-Commerce platform based on Django.
 
 ## Editor Plugins and IDEs
 
@@ -671,7 +670,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Gooey](https://github.com/chriskiehl/Gooey) - Turn command line programs into a full GUI application with one line.
 * [kivy](https://kivy.org/) - A library for creating NUI applications, running on Windows, Linux, Mac OS X, Android and iOS.
 * [pyglet](https://github.com/pyglet/pyglet) - A cross-platform windowing and multimedia library for Python.
-* [PyGObject](https://wiki.gnome.org/Projects/PyGObject) - Python Bindings for GLib/GObject/GIO/GTK+ (GTK+3).
+* [PyGObject](https://pygobject.readthedocs.io/) - Python Bindings for GLib/GObject/GIO/GTK+ (GTK+3).
 * [PyQt](https://doc.qt.io/qtforpython/) - Python bindings for the [Qt](https://www.qt.io/) cross-platform application and UI framework.
 * [PySimpleGUI](https://github.com/PySimpleGUI/PySimpleGUI) - Wrapper for tkinter, Qt, WxPython and Remi.
 * [pywebview](https://github.com/r0x0r/pywebview/) - A lightweight cross-platform native wrapper around a webview component.
@@ -695,7 +694,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 *Awesome game development libraries.*
 
 * [Arcade](https://api.arcade.academy/en/latest/) - Arcade is a modern Python framework for crafting games with compelling graphics and sound.
-* [Cocos2d](http://cocos2d.org/) - cocos2d is a framework for building 2D games, demos, and other graphical/interactive applications.
+* [Cocos2d](https://www.cocos.com/en/cocos2d-x) - cocos2d is a framework for building 2D games, demos, and other graphical/interactive applications.
 * [Harfang3D](http://www.harfang3d.com) - Python framework for 3D, VR and game development.
 * [Panda3D](https://www.panda3d.org/) - 3D game engine developed by Disney.
 * [Pygame](http://www.pygame.org/news.html) - Pygame is a set of Python modules designed for writing games.
@@ -762,7 +761,6 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [pagan](https://github.com/daboth/pagan) - Retro identicon (Avatar) generation based on input string and hash.
 * [pillow](https://github.com/python-pillow/Pillow) - Pillow is the friendly [PIL](http://www.pythonware.com/products/pil/) fork.
 * [python-barcode](https://github.com/WhyNotHugo/python-barcode) - Create barcodes in Python with no extra dependencies.
-* [pygram](https://github.com/ajkumar25/pygram) - Instagram-like image filters.
 * [PyMatting](http://github.com/pymatting/pymatting) - A library for alpha matting.
 * [python-qrcode](https://github.com/lincolnloop/python-qrcode) - A pure Python QR Code generator.
 * [pywal](https://github.com/dylanaraps/pywal) - A tool that generates color schemes from images.
@@ -1005,7 +1003,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [hug](https://github.com/hugapi/hug) - A Python 3 framework for cleanly exposing APIs.
     * [sandman2](https://github.com/jeffknupp/sandman2) - Automated REST APIs for existing database-driven systems.
     * [sanic](https://github.com/huge-success/sanic) - A Python 3.6+ web server and web framework that's written to go fast.
-    * [vibora](https://vibora.io/) - Fast, efficient and asynchronous Web framework inspired by Flask.
+    * [vibora](https://docs.vibora.io/) - Fast, efficient and asynchronous Web framework inspired by Flask.
 
 ## Robotics
 
@@ -1036,7 +1034,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [NIPY](http://nipy.org) - A collection of neuroimaging toolkits.
 * [NumPy](http://www.numpy.org/) - A fundamental package for scientific computing with Python.
 * [ObsPy](https://github.com/obspy/obspy/wiki/) - A Python toolbox for seismology.
-* [Open Babel](http://openbabel.org/wiki/Main_Page) - A chemical toolbox designed to speak the many languages of chemical data.
+* [Open Babel](https://open-babel.readthedocs.io/) - A chemical toolbox designed to speak the many languages of chemical data.
 * [PyDy](http://www.pydy.org/) - Short for Python Dynamics, used to assist with workflow in the modeling of dynamic motion.
 * [PyMC](https://github.com/pymc-devs/pymc3) - Markov Chain Monte Carlo sampling toolkit.
 * [QuTiP](http://qutip.org/) - Quantum Toolbox in Python.
@@ -1339,7 +1337,6 @@ Where to discover learning resources or new Python libraries.
     * [Awesome Python @LibHunt](https://python.libhunt.com/)
 * Others
     * [Python ZEEF](https://python.zeef.com/alan.richmond)
-    * [Pythonic News](https://news.python.sc/)
     * [What the f*ck Python!](https://github.com/satwikkansal/wtfpython)
 
 ## Newsletters


### PR DESCRIPTION
UPDATED:
Line 191: [BitBake](http://www.yoctoproject.org/docs/1.6/bitbake-user-manual/bitbake-user-manual.html) 
Old version docs no longer at this URL.

Line 415: [psycopg2](http://initd.org/psycopg/)
Permanently moved to new site.

Line 571: [shoop](https://www.shuup.com/en/)
/en/ is 404, removed.

Line 674: [PyGObject](https://wiki.gnome.org/Projects/PyGObject) 
Permanently moved to new URL.

Line 698: [Cocos2d](http://cocos2d.org/)
Permanently moved to new URL.

Line 1008: [vibora](https://vibora.io/)
This library was recently archived, also homepage is 404 but docs.vibora.io is functional.

Line 1039: [Open Babel](http://openbabel.org/wiki/Main_Page) 
Permanently moved to new URL.

REMOVED:
Line 427: [py2neo](https://py2neo.org/)
Project is EOL.

Line 765: [pygram](https://github.com/ajkumar25/pygram) 
Library no longer exists?

Line 1342: [Pythonic News](https://news.python.sc/) 
Entire site is 404.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
