### PR TITLE
Fix pylint link

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [flake8](https://pypi.org/project/flake8/) - A wrapper around `pycodestyle`, `pyflakes` and McCabe.
         * [awesome-flake8-extensions](https://github.com/DmytroLitvinov/awesome-flake8-extensions)
     * [pylama](https://github.com/klen/pylama) - A code audit tool for Python and JavaScript.
-    * [pylint](https://www.pylint.org/) - A fully customizable source code analyzer.
+    * [pylint](https://pylint.readthedocs.io/en/latest/) - A fully customizable source code analyzer.
     * [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) - The strictest and most opinionated python linter ever.
 * Code Formatters
     * [black](https://github.com/python/black) - The uncompromising Python code formatter.


### PR DESCRIPTION
As mentioned in this discussion https://github.com/pylint-dev/pylint/issues/7384 the pylint dot org domain is no longer associated with the python linter. Change the name to the one linked in the GitHub Repo.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
