### PR TITLE
add ruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [pycallgraph](https://github.com/gak/pycallgraph) - A library that visualises the flow (call graph) of your Python application.
     * [vulture](https://github.com/jendrikseipp/vulture) - A tool for finding and analysing dead Python code.
 * Code Linters
+    * [ruff](https://github.com/astral-sh/ruff) - An extremely fast linter and code formatter, integrating more functionality
     * [flake8](https://pypi.org/project/flake8/) - A wrapper around `pycodestyle`, `pyflakes` and McCabe.
         * [awesome-flake8-extensions](https://github.com/DmytroLitvinov/awesome-flake8-extensions)
     * [pylama](https://github.com/klen/pylama) - A code audit tool for Python and JavaScript.


### PR DESCRIPTION
## What is this Python project?

An extremely fast Python linter and code formatter, written in Rust.

## What's the difference between this Python project and similar ones?

- 10-100x faster than existing linters (like Flake8) and formatters (like Black)
- Installable via pip
- pyproject.toml support
- Python 3.12 compatibility
- Drop-in parity with [Flake8](https://docs.astral.sh/ruff/faq/#how-does-ruff-compare-to-flake8), isort, and Black
- Built-in caching, to avoid re-analyzing unchanged files
- Fix support, for automatic error correction (e.g., automatically remove unused imports)
- Over [700 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations of popular Flake8 plugins, like flake8-bugbear
- First-party [editor integrations](https://docs.astral.sh/ruff/integrations/) for [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://github.com/astral-sh/ruff-lsp)
- Monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#pyprojecttoml-discovery)

Anyone who agrees with this pull request could submit an *Approve* review to it.
