### PR TITLE
Add auto-py-to-exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries to create packaged executables for release distribution.*
 
+* [auto-py-to-exe](https://github.com/brentvollebregt/auto-py-to-exe) - Converts .py to .exe using a user friendly graphical interface.
 * [py2app](https://github.com/ronaldoussoren/py2app) - Freezes Python scripts (Mac OS X).
 * [py2exe](https://github.com/py2exe/py2exe) - Freezes Python scripts (Windows).
 * [pyarmor](https://github.com/dashingsoft/pyarmor) - A tool used to obfuscate python scripts, bind obfuscated scripts to fixed machine or expire obfuscated scripts.


### PR DESCRIPTION
## What is this Python project?

This project uses [Pyinstaller](https://github.com/pyinstaller/pyinstaller) to convert from the .py file format to .exe format. The notable difference is that this project uses a very user-friendly graphical interface for users to select options to convert the python code into executable format.

## What's the difference between this Python project and similar ones?

Like it was said above, [auto-py-to-exe](https://github.com/brentvollebregt/auto-py-to-exe) uses a very simple and easy to use graphical interface to allow users to create standalone executables along with dependencies as files. The GUI is translated into 27 different langauges. 

It makes the pyinstaller commands into simple point and click bottons that add the feature into the command line which is shown in the GUI. It seperates the input command from the output display/terminal. All of this is done within the application. Users have the option to chose whether they like to use the built in terminal display in the GUI, or use their native console.

Any user can use it without any experiance with [Pyinstaller](https://github.com/pyinstaller/pyinstaller). They do not need to learn any of the pyinstaller commands due to the simplistic nature of the GUI. The words on the bottons help the user understand what each option does. The GUI also displays the [Pyinstaller](https://github.com/pyinstaller/pyinstaller) commands above the simple bottons for each command.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
