### PR TITLE
Add Piccolo to ORM list

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [peewee](https://github.com/coleifer/peewee) - A small, expressive ORM.
     * [pony](https://github.com/ponyorm/pony/) - ORM that provides a generator-oriented interface to SQL.
     * [pydal](https://github.com/web2py/pydal/) - A pure Python Database Abstraction Layer.
+    * [Piccolo](https://github.com/piccolo-orm/piccolo) - A fast, user friendly ORM and query builder which supports asyncio. 
 * NoSQL Databases
     * [hot-redis](https://github.com/stephenmcd/hot-redis) - Rich Python data types for Redis.
     * [mongoengine](https://github.com/MongoEngine/mongoengine) - A Python Object-Document-Mapper for working with MongoDB.


### PR DESCRIPTION
I was looking at the page for ORMs and also asking a friend @martinpeck for recommendations. 

He suggested Piccolo which wasn't in the list so added it in case it's useful for others.

## What is this Python project?

Piccolo

## What's the difference between this Python project and similar ones?

Their [page here](https://piccolo-orm.com/blog/why-choose-piccolo/) does comparisons to other ORMS

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
