### PR TITLE
Add Crawlee for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,10 +1133,12 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries to automate web scraping.*
 
+* [crawlee-python](https://github.com/apify/crawlee-python) - A web scraping and browser automation library to build reliable scrapers fast.
 * [feedparser](https://github.com/kurtmckee/feedparser) - Universal feed parser.
 * [grab](https://github.com/lorien/grab) - Site scraping framework.
 * [mechanicalsoup](https://github.com/MechanicalSoup/MechanicalSoup) - A Python library for automating interaction with websites.
 * [scrapy](https://github.com/scrapy/scrapy) - A fast high-level screen scraping and web crawling framework.
+
 
 ## Web Frameworks
 


### PR DESCRIPTION
## What is this Python project?

[Crawlee for Python](https://github.com/apify/crawlee-python/) is a web scraping and browser automation library that quickly builds reliable scrapers in Python.

## What's the difference between this Python project and similar ones?

Similar to Scrapy.

- You can scrape in both HTTP and headless browser modes.
- Use BeautifoulSoupCrawler to scrape static pages and PlaywrightCrawler to scrape dynamic JS-rendered websites.
- No need to install any plugins or set up middleware.
- Completely typed hint in Python.
- work with windows as well.


Anyone who agrees with this pull request could submit an *Approve* review to it.
