### PR TITLE
Add uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [PyPI](https://pypi.org/)
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [poetry](https://github.com/sdispater/poetry) - Python dependency management and packaging made easy.
+* [uv](https://github.com/astral-sh/uv) - An extremely fast Python package and project manager, written in Rust.
 
 ## Package Repositories
 


### PR DESCRIPTION
## What is this Python project?

**uv** is an extremely fast Python package and project manager, it extends beyond a pip alternative, and more into an end-to-end solution for managing command-line tools, single-file scripts, and even Python itself.

### Highlights

*  A single tool to replace `pip`, `pip-tools`, `pipx`, `poetry`, `pyenv`, `virtualenv`, and more.
*  10-100x faster than `pip`.
*  Installs and manages Python versions.
*  Runs and installs Python applications.
*  Runs single-file scripts, with support for inline dependency metadata.
*  Provides comprehensive project management, with a universal lockfile.
*  Includes a pip-compatible interface for a performance boost with a familiar CLI.
* Supports Cargo-style workspaces for scalable projects.
* Disk-space efficient, with a global cache for dependency deduplication.
* Installable without Rust or Python via `curl` or `pip`.
* Supports macOS, Linux, and Windows.

## What's the difference between this Python project and similar ones?

* The main difference is the speed creating the environments
* The command line interface is clear in every aspect

I have been tracking these project for a while and look really interting, I just tried to install the depencies of a project with this an Python Poetry (my package management tool for years) and it took 20 s with **uv** against 61 s from **Poetry**


Anyone who agrees with this pull request could submit an *Approve* review to it.
