### PR TITLE
Add polifactory to Testing:Object factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1035,6 +1035,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [factory_boy](https://github.com/FactoryBoy/factory_boy) - A test fixtures replacement for Python.
     * [mixer](https://github.com/klen/mixer) - Another fixtures replacement. Supports Django, Flask, SQLAlchemy, Peewee and etc.
     * [model_mommy](https://github.com/vandersonmota/model_mommy) - Creating random fixtures for testing in Django.
+    * [polyfactory](https://github.com/litestar-org/polyfactory) - mock data generation library with support to classes (continuation of `pydantic-factories`)
 * Code Coverage
     * [coverage](https://pypi.org/project/coverage/) - Code coverage measurement.
 * Fake Data


### PR DESCRIPTION
## What is this Python project?

A Factory or Mother library with mock data features

## What's the difference between this Python project and similar ones?

It is somewhat similar to factory-boy (already listed) but I find it simpler with a softer initial learning curve.

I've been working with `factory-boy` for years and I am a big supporter but `polyfactory` makes it simpler to achieve the most common fixture generations.

If you are starting with fixture generation I would recommend going to `polyfactory` first or at least taking a look and comparing it with `factory-boy`, especially if you work with Pydantic.


--

Anyone who agrees with this pull request could submit an *Approve* review to it.
