### PR TITLE
:triangular_flag_on_post: an extra accuracy README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [django-activity-stream](https://github.com/justquick/django-activity-stream) - Generating generic activity streams from the actions on your site.
 * [Stream Framework](https://github.com/tschellenbach/Stream-Framework) - Building news feed and notification systems using Cassandra and Redis.
 
-## ORM
+## ORM and other database mapping tools
 
 *Libraries that implement Object-Relational Mapping or data mapping techniques.*
 


### PR DESCRIPTION
"ORM" may not encompass all database mapping tools, and the new phrasing provides clarity for users who might be unfamiliar with the term. But I believe the term "ORM" is so popular, especially around newcomers that dropping that from the title might be a bad idea. the Object Relational Mapper has an emphasis on the "Relational" side.

## What is this Python project?

Describe features.

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
