### PR TITLE
Add ruff linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [flake8](https://github.com/PyCQA/flake8) - A wrapper around `pycodestyle`, `pyflakes` and McCabe.
         * [awesome-flake8-extensions](https://github.com/DmytroLitvinov/awesome-flake8-extensions)
     * [pylint](https://github.com/pylint-dev/pylint) - A fully customizable source code analyzer.
+    * [ruff](https://docs.astral.sh/ruff/) - An extremely fast Python linter and code formatter.
 * Code Formatters
     * [black](https://github.com/psf/black) - The uncompromising Python code formatter.
     * [isort](https://github.com/timothycrosley/isort) - A Python utility / library to sort imports.


### PR DESCRIPTION
## What is this Python project?

An extremely fast Python linter and code formatter, written in Rust.

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

⚡️ 10-100x faster than existing linters (like Flake8) and formatters (like Black)
🐍 Installable via pip
🛠️ pyproject.toml support
🤝 Python 3.13 compatibility
⚖️ Drop-in parity with [Flake8](https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-flake8), isort, and [Black](https://docs.astral.sh/ruff/faq/#how-does-ruffs-formatter-compare-to-black)
📦 Built-in caching, to avoid re-analyzing unchanged files
🔧 Fix support, for automatic error correction (e.g., automatically remove unused imports)
📏 Over [800 built-in rules](https://docs.astral.sh/ruff/rules/), with native re-implementations of popular Flake8 plugins, like flake8-bugbear
⌨️ First-party [editor integrations](https://docs.astral.sh/ruff/integrations/) for [VS Code](https://github.com/astral-sh/ruff-vscode) and [more](https://docs.astral.sh/ruff/editors/setup/)
🌎 Monorepo-friendly, with [hierarchical and cascading configuration](https://docs.astral.sh/ruff/configuration/#config-file-discovery)

Anyone who agrees with this pull request could submit an *Approve* review to it.
