### PR TITLE
Add Pyved-engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [PyOgre](http://www.ogre3d.org/tikiwiki/PyOgre) - Python bindings for the Ogre 3D render engine, can be used for games, simulations, anything 3D.
 * [PyOpenGL](http://pyopengl.sourceforge.net/) - Python ctypes bindings for OpenGL and it's related APIs.
 * [PySDL2](https://pysdl2.readthedocs.io) - A ctypes based wrapper for the SDL2 library.
+* [Pyved-engine](https://pyved-solution.github.io/pyved-engine/) - Innovative 2D game engine for structured game creation and HTML5 exports.
 * [RenPy](https://www.renpy.org/) - A Visual Novel engine.
 
 ## Geolocation


### PR DESCRIPTION
## What is this Python project? (Pyved-engine)

An innovative game engine that focuses on easing 2D game creation.
<img src="https://github.com/user-attachments/assets/5c808760-dbd1-4666-b204-957ca0e2592b" alt="preview pyved games" width="640"/>

**The reason why the library is awesome:**
A major benefit of using pyved-engine is its ability to export games in the HTML5 format, allowing for online play.

For example, on [this page](https://pyvm.kata.games/play/ecsRogue) you can see how a python game is being "played" in the web context (__before optimization__, but after automatic Python to HTML5 conversion)

## What's the difference between this Python project and similar ones?

- Dedicated tool in command-line, that allows the use of game templates so the developer almost never starts from scratch. This is a major difference compared to `pygame`, for instance
![{43E0658F-8298-4FA6-8C7F-41A496704C29}](https://github.com/user-attachments/assets/11fd7cb7-b904-4b7c-b2a5-f00a49dd15fd)

- Dedicated gamedev API designed to simplify and enhance event-based programming.
- Simple tools for creating isometric games
- Heavy use of design patterns for a structured game development process
- Versatile engine with extensive submodules (e.g., tabletop, isometric, RPG, pathfinding, etc.)
- Supports HTML5 export for web-based game deployment

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
