### PR TITLE
Add markitdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,6 +960,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Markdown
     * [Mistune](https://github.com/lepture/mistune) - Fastest and full featured pure Python parsers of Markdown.
     * [Python-Markdown](https://github.com/waylan/Python-Markdown) - A Python implementation of John Gruber’s Markdown.
+    * [markitdown](https://github.com/microsoft/markitdown) - Tool for converting files and office documents to Markdown.
 * YAML
     * [PyYAML](http://pyyaml.org/) - YAML implementations for Python.
 * CSV
@@ -1197,4 +1198,3 @@ Your contributions are always welcome! Please take a look at the [contribution g
 - - -
 
 If you have any question about this opinionated list, do not hesitate to contact me [@VintaChen](https://twitter.com/VintaChen) on Twitter or open an issue on GitHub.
-


### PR DESCRIPTION
## What is this Python project?

This is a utility tool for converting various files into Markdown (e.g., for indexing, text analysis, etc)
At this moment, it supports: PDF, PowerPoint, Word, Excel, Images (EXIF metadata and OCR), Audio (EXIF metadata and speech transcription), HTML, Text-based formats (CSV, JSON, XML), ZIP files (iterates over contents)

## What's the difference between this Python project and similar ones?

Most of the package comparisons I found, do the conversion from a specific format, like pdf or excel into Markdown. This does many from just this package.
Microsoft recently open sourced the repository, so it will have maintenance and growth. 

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
