### PR TITLE
Ensure consistency by adding missing period in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 ## Serialization
 
-*Libraries for serializing complex data types*
+*Libraries for serializing complex data types.*
 
 * [marshmallow](https://github.com/marshmallow-code/marshmallow) - A lightweight library for converting complex objects to and from simple Python datatypes.
 * [pysimdjson](https://github.com/TkTech/pysimdjson) - A Python bindings for [simdjson](https://github.com/lemire/simdjson).


### PR DESCRIPTION
Added a missing period at the end of a specific line in the README to maintain consistency with similar lines. All other lines of this type included a period, and this correction ensures uniform formatting and readability.

## What is this Python project?

Describe features.

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
