### PR TITLE
Add project-PortablePythonBundlesOnWindows

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 *Libraries to create packaged executables for release distribution.*
 
+* [Portable Python Bundles on MS Windows](https://dev.to/treehouse/portable-python-bundles-on-windows-41ac) - a distribution technique for self-contained Python environments on Windows. Between venvs and PyInstaller.
 * [py2app](https://github.com/ronaldoussoren/py2app) - Freezes Python scripts (Mac OS X).
 * [py2exe](https://github.com/py2exe/py2exe) - Freezes Python scripts (Windows).
 * [pyarmor](https://github.com/dashingsoft/pyarmor) - A tool used to obfuscate python scripts, bind obfuscated scripts to fixed machine or expire obfuscated scripts.


### PR DESCRIPTION
## What is this Python project?

This is a technique for creating Portable Python Bundles on MS Windows. Bundles are like venvs - but are self-contained and path-independent. An alternative to venvs and executables created with PyInstaller.

## What's the difference between this Python project and similar ones?

It's a convention that fills a gap for packaging and distribution Python environments and applications on MS Windows. Bundles have the advantages of being a full Python environment - similar to venvs - , so you can install packages with `pip`, use them in an IDE, etc. But are self-contained, path-independent and portable to other Windows machines similar to PyInstaller-created single executables.

