### PR TITLE
Add Nuitka

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [py2exe](https://github.com/py2exe/py2exe) - Freezes Python scripts (Windows).
 * [pyarmor](https://github.com/dashingsoft/pyarmor) - A tool used to obfuscate python scripts, bind obfuscated scripts to fixed machine or expire obfuscated scripts.
 * [pyinstaller](https://github.com/pyinstaller/pyinstaller) - Converts Python programs into stand-alone executables (cross-platform).
+* [nuitka](https://github.com/Nuitka/Nuitka) -  Translates the Python modules into a C level program that then uses and static C files of its own to execute in the same way as CPython does.
 * [shiv](https://github.com/linkedin/shiv) - A command line utility for building fully self-contained zipapps (PEP 441), but with all their dependencies included.
 
 ## Documentation


### PR DESCRIPTION
## What is this Python project?

> Nuitka translates the Python modules into a C level program that then uses and static C files of its own to execute in the same way as CPython does.


A project of python program distribution.

## What's the difference between this Python project and similar ones?

1. It convert the program to C level program first, so it obviously has higher performance.
2. It has not only free edition, but also a commercial edition.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
