### PR TITLE
Add meatie library to HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [httpx](https://github.com/encode/httpx) - A next generation HTTP client for Python.
 * [requests](https://github.com/psf/requests) - HTTP Requests for Humans.
+* [meatie](https://github.com/pmateusz/meatie) - Generates code for calling REST endpoints based on method signatures annotated with type hints.
 * [treq](https://github.com/twisted/treq) - Python requests like API built on top of Twisted's HTTP client.
 * [urllib3](https://github.com/urllib3/urllib3) - A HTTP library with thread-safe connection pooling, file post support, sanity friendly.
 


### PR DESCRIPTION
## What is this Python project?

Meatie is a Python library that simplifies the implementation of REST API clients. The library generates code for calling REST endpoints based on method signatures annotated with type hints. Meatie takes care of mechanics related to HTTP communication, such as building URLs, encoding query parameters, and serializing the body in the HTTP requests and responses. Rate limiting, retries, and caching are available with some modest extra setup.

Meatie works with all major HTTP client libraries (request, httpx, aiohttp) and offers seamless integration with Pydantic (v1 and v2). The minimum officially supported version is Python 3.9.

## What's the difference between this Python project and similar ones?

- **Rapid REST API Client Implementation**: Eliminate boilerplate tasks such as URL assembly and request/response body serialization. Meatie automatically generates HTTP requests using type hints and annotations.
- **Optional Pydantic Integration**: Serialize request and response bodies with seamless integration with Pydantic.
- **Built-in Rate Limiting, Caching, and Retries**: More advanced features required for writing reliable, production-ready REST API clients are integrated with the library and optimized for ease of use.


--

Anyone who agrees with this pull request could submit an *Approve* review to it.
