### PR TITLE
Add Scalekit

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [django-allauth](https://github.com/pennersr/django-allauth) - Authentication app for Django that "just works."
     * [django-oauth-toolkit](https://github.com/jazzband/django-oauth-toolkit) - OAuth 2 goodies for Django.
     * [oauthlib](https://github.com/oauthlib/oauthlib) - A generic and thorough implementation of the OAuth request-signing logic.
+    * [scalekit-sdk-python](https://github.com/scalekit-inc/scalekit-sdk-python) - Add enterprise SSO and SCIM provisioning without rewriting existing auth flows.
+
 * JWT
     * [pyjwt](https://github.com/jpadilla/pyjwt) - JSON Web Token implementation in Python.
     * [python-jose](https://github.com/mpdavis/python-jose/) - A JOSE implementation in Python.


### PR DESCRIPTION
Scalekit’s Python SDK enables B2B SaaS teams to add enterprise SSO (SAML, OIDC) and SCIM provisioning capabilities on top of existing authentication providers like Firebase, Cognito, or Auth0 — without needing to rewrite auth logic.

The SDK is:
- Python-native
- Designed for developer productivity (typed models, helpers, request/response handling)

Let me know if you'd like this phrased differently or placed in another category. Thanks for maintaining this awesome list!

## What is this Python project?

Describe features.

## What's the difference between this Python project and similar ones?

Enumerate comparisons.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
