### PR TITLE
Add uv package to Package Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [PyPI](https://pypi.org/)
 * [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
 * [poetry](https://github.com/sdispater/poetry) - Python dependency management and packaging made easy.
+* [uv](https://github.com/astral-sh/uv) - Extremely fast Python package installer and resolver, written in Rust.
 
 ## Package Repositories
 


### PR DESCRIPTION
This PR adds `uv`, a new Rust-based Python package installer and resolver by Astral, under the Package Management section. It's known for its extreme speed and efficiency.
