### PR TITLE
Add `sqlazo` module to 'Database' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [pickleDB](https://github.com/patx/pickledb) - A simple and lightweight key-value store for Python.
 * [tinydb](https://github.com/msiemens/tinydb) - A tiny, document-oriented database.
 * [zodb](https://github.com/zopefoundation/ZODB) - A native object database for Python. A key-value and object graph database.
+* [sqlazo](https://github.com/tutosrive/sqlazo) - A module that allows you to manage basic procedures in a database with SQLite3
 
 ## Database Drivers
 


### PR DESCRIPTION
## What is this Python project?

SQLAZO is a module for managing SQLite databases via a simple `Database` class. It provides methods like `create_table`, `insert_data`, `get_data_all`, `get_data_where` and `delete_data` to perform standard CRUD operations.

```shell
pip install sqlazo
```

## What’s the difference between this Python project and similar ones?

| Aspect            | SQLAZO                                         | sqlite3 (stdlib)                               | SQLModel / SQLAlchemy                         |
|-------------------|-----------------------------------------------|------------------------------------------------|-----------------------------------------------|
| **API Level**     | High-level methods for common tasks           | Low-level cursor and connection                | Declarative ORM with models and sessions     |
| **Ease of Use**   | One class covers create, read and delete | You write raw SQL  | You define models, more boilerplate          |
| **Dependencies**  | Depends on `sqlite3` only, `chromologger` | Standard library only                          | External packages |
| **Use Case**      | Quick scripts and small apps                  | Built-in DB access for general Python          | Large applications needing complex schemas   |

Anyone who agrees with this pull request could submit an *Approve* review to it.
