### PR TITLE
add mininterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [cement](https://github.com/datafolklabs/cement) - CLI Application Framework for Python.
     * [click](https://github.com/pallets/click/) - A package for creating beautiful command line interfaces in a composable way.
     * [cliff](https://github.com/openstack/cliff) - A framework for creating command-line programs with multi-level commands.
+    * [mininterface](https://github.com/CZ-NIC/mininterface) - A dialog toolkit that makes command line interface interactive.
     * [python-fire](https://github.com/google/python-fire) - A library for creating command line interfaces from absolutely any Python object.
     * [python-prompt-toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit) - A library for building powerful interactive command lines.
 * Terminal Rendering


### PR DESCRIPTION
## What is this Python project?

Mininterface is an argparse alternative and drop-in replacement that exposes configuration options to the CLI, but also to GUI and TUI. This allows your script seamlessly to run everywhere, on a desktop, web, or a headless machine. It's a dialog toolkit that lets the developer focus on their program's logic, not on how users interact with it.

## What's the difference between this Python project and similar ones?

* No other project enables a single script to work simultaneously as a CLI tool, desktop app, and terminal application. Typically, you'd have to choose one or build each interface separately.
* Provides helpful output in both the CLI and IDEs through type hints. The other project don't show IDE type hints well.
* It requires just one line to enable, with zero learning curve for developers.

--

Anyone who agrees with this pull request could submit an Approve review to it.
