### PR TITLE
Add `apitally` to RESTful API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,6 +859,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Pyramid
     * [cornice](https://github.com/Cornices/cornice) - A RESTful framework for Pyramid.
 * Framework agnostic
+    * [apitally](https://github.com/apitally/apitally-py) - A simple API monitoring, analytics, and request logging tool. Supports FastAPI, Django, Flask, and other frameworks.
     * [falcon](https://github.com/falconry/falcon) - A high-performance framework for building cloud APIs and web app backends.
     * [fastapi](https://github.com/tiangolo/fastapi) - A modern, fast, web framework for building APIs with Python 3.6+ based on standard Python type hints.
     * [hug](https://github.com/hugapi/hug) - A Python 3 framework for cleanly exposing APIs.


### PR DESCRIPTION
## What is this Python project?

[Apitally](https://github.com/apitally/apitally-py) is a lightweight API monitoring, analytics, and request logging tool. It helps developers understand API usage, performance, and errors – without setting up complex infrastructure.

Supported web frameworks include:

- FastAPI / Starlette
- Django REST Framework / Django Ninja
- Flask
- Litestar
- BlackSheep

Why it’s awesome:

- Clear, focused dashboards – See API traffic, performance, errors, and consumer behaviour at a glance.
- Minimal setup – Just a few lines of code to get started.
- Privacy-friendly by design – Metrics are aggregated client-side; request logging is fully optional and configurable.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.