### PR TITLE
Add Dispytch to Asynchronous Programming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [uvloop](https://github.com/MagicStack/uvloop) - Ultra fast asyncio event loop.
 * [eventlet](https://github.com/eventlet/eventlet) - Asynchronous framework with WSGI support.
 * [gevent](https://github.com/gevent/gevent) - A coroutine-based Python networking library that uses [greenlet](https://github.com/python-greenlet/greenlet).
+* [dispytch](https://github.com/e1-m/dispytch) - A lightweight, async-first Python framework for event-driven services.
 
 ## Audio
 


### PR DESCRIPTION
## What is this Python project?

[Dispytch](https://github.com/e1-m/dispytch) is a lightweight, async-first Python framework for event-handling. It’s designed to streamline the development of clean and testable event-driven services.

## Features
Async-first core – built for modern Python I/O
FastAPI-style dependency injection – clean, decoupled handlers
Backend-flexible – with Kafka and RabbitMQ out-of-the-box
Composable architecture – extend, override, or inject anything
Pydantic-based validation – event schemas are validated using pydantic
Built-in retry logic – configurable, resilient, no boilerplate

## What's the difference between this Python project and similar ones?
vs Celery: Dispytch is not tied to task queues or background jobs. It treats events as first-class entities, not side tasks.

vs Faust: Faust is opinionated toward stream processing (à la Kafka). Dispytch is backend-agnostic and doesn’t assume streaming.

vs Nameko: Nameko is heavier, synchronous by default, and tied to RPC-style services. Dispytch is lean, async-first, and modular.

vs FastAPI: FastAPI is HTTP-centric. Dispytch is protocol-agnostic — it’s about event handling, not API routing.