### PR TITLE
Add mpi4py!

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * Batch Processing
     * [dask](https://github.com/dask/dask) - A flexible parallel computing library for analytic computing.
     * [luigi](https://github.com/spotify/luigi) - A module that helps you build complex pipelines of batch jobs.
+    * [mpi4py](https://github.com/mpi4py/mpi4py) - Python bindings for MPI.
     * [PySpark](https://github.com/apache/spark) - [Apache Spark](https://spark.apache.org/) Python API.
     * [Ray](https://github.com/ray-project/ray/) - A system for parallel and distributed Python that unifies the machine learning ecosystem.
 * Stream Processing


### PR DESCRIPTION
## What is this Python project?

mpi4py provides python bindings for MPI.

## What's the difference between this Python project and similar ones?

This is easiest way to use MPI from Python. MPI is ubiquitous in HPC and runs on virtually every supercomputer.

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
