### PR TITLE
Add CN-Kaltools

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [tmuxp](https://github.com/tmux-python/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.
     * [try](https://github.com/timofurrer/try) - A dead simple CLI to try out python packages - it's never been easier.
 * CLI Enhancements
+    
+    * [CN-Kaltools](https://github.com/CyberNaught-XyZ/CN-Kaltools) - A Python tool for temporarily installing Kali Linux metapackages on non-Kali systems without permanent changes, ideal for penetration testers needing quick access to Kali tools in non-Kali environments.
     * [httpie](https://github.com/httpie/cli) - A command line HTTP client, a user-friendly cURL replacement.
     * [iredis](https://github.com/laixintao/iredis) - Redis CLI with autocompletion and syntax highlighting.
     * [litecli](https://github.com/dbcli/litecli) - SQLite CLI with autocompletion and syntax highlighting.


### PR DESCRIPTION
Commit Comment Template:

Project Name:

[CN-Kaltools](https://github.com/CyberNaught-XyZ/CN-Kaltools?utm_source=chatgpt.com)
 - A Python tool for temporarily installing Kali Linux metapackages on non-Kali systems without permanent changes, ideal for penetration testers needing quick access to Kali tools in non-Kali environments.

What is this Python project?

CN-Kaltools is a Python-based tool designed to help penetration testers and security professionals quickly install Kali Linux metapackages on non-Kali systems without making permanent changes to the underlying OS. It provides a fast, temporary solution for gaining access to a set of powerful Kali tools, which are often essential for network scanning, vulnerability assessment, and penetration testing. The tool leverages Python's ability to automate the process of downloading and installing the necessary metapackages, ensuring a clean and efficient setup.

Key features include:

Temporary installation: Tools are installed without modifying the host system permanently.

Easy to use: Simple command-line interface for easy integration into existing workflows.

Kali Linux toolset: Provides access to a wide range of tools commonly used for penetration testing and security assessments.

No dependency issues: Avoids the complications of installing Kali on a non-Kali system by temporarily accessing the tools via Python.

What's the difference between this Python project and similar ones?

Unlike traditional methods of installing Kali Linux tools (such as installing Kali itself or using Docker), CN-Kaltools offers a temporary, no-commit installation process, allowing users to access the tools without permanently altering their system environment.

Some comparisons to other tools:

Kali Linux: Requires installing a full Kali system or running a virtual machine, which might be overkill if you only need specific tools.

Docker: While Docker containers can isolate Kali tools, they require additional setup and configuration, and they might not always support all tools in the Kali suite.

Virtualization (VMs): Running a full VM with Kali Linux is resource-intensive and can be cumbersome if you only need specific tools temporarily.

CN-Kaltools, on the other hand, provides an efficient, lightweight, and quick method for installing only the tools you need, without the complexity and resource overhead of virtualization or Docker.