### PR TITLE
Add SQLModel to ORM section

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [Django Models](https://docs.djangoproject.com/en/dev/topics/db/models/) - The Django ORM.
     * [SQLAlchemy](https://www.sqlalchemy.org/) - The Python SQL Toolkit and Object Relational Mapper.
         * [awesome-sqlalchemy](https://github.com/dahlia/awesome-sqlalchemy)
+    * [SQLModel](https://sqlmodel.tiangolo.com/) - SQLModel is based on Python type annotations, and powered by Pydantic and SQLAlchemy.
     * [dataset](https://github.com/pudo/dataset) - Store Python dicts in a database - works with SQLite, MySQL, and PostgreSQL.
     * [orator](https://github.com/sdispater/orator) -  The Orator ORM provides a simple yet beautiful ActiveRecord implementation.
     * [orm](https://github.com/encode/orm) - An async ORM.


### PR DESCRIPTION
This PR adds [SQLModel](https://sqlmodel.tiangolo.com/) to the ORM section under Relational Databases. 
