### PR TITLE
Update Selenium links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1021,7 +1021,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
     * [locust](https://github.com/locustio/locust) - Scalable user load testing tool written in Python.
     * [PyAutoGUI](https://github.com/asweigart/pyautogui) - PyAutoGUI is a cross-platform GUI automation Python module for human beings.
     * [Schemathesis](https://github.com/kiwicom/schemathesis) - A tool for automatic property-based testing of web applications built with Open API / Swagger specifications.
-    * [Selenium](https://pypi.org/project/selenium/) - Python bindings for [Selenium](http://www.seleniumhq.org/) WebDriver.
+    * [Selenium](https://pypi.org/project/selenium/) - Python bindings for [Selenium](https://selenium.dev/) [WebDriver](https://selenium.dev/documentation/webdriver/).
     * [sixpack](https://github.com/seatgeek/sixpack) - A language-agnostic A/B Testing framework.
     * [splinter](https://github.com/cobrateam/splinter) - Open source tool for testing web applications.
 * Mock


### PR DESCRIPTION
This PR updates the outdated URL for Selenium (and adds a new link to the WebDriver subsection of the Selenium site)

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
