### PR TITLE
Add llm-cost-profiler under Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [django-ai-plugins](https://github.com/vintasoftware/django-ai-plugins) - Django backend agent skills for Django, DRF, Celery, and Django-specific code review.
   - [sentry-skills](https://github.com/getsentry/skills) - Python-focused engineering skills for code review, debugging, and backend workflows.
   - [trailofbits-skills](https://github.com/trailofbits/skills) - Python-friendly security skills for auditing, testing, and safer backend development.
+  - [llm-cost-profiler](https://github.com/BuildWithAbid/llm-cost-profiler) - Track, visualize, and optimize LLM API spending with two lines of code.
 - Orchestration
   - [autogen](https://github.com/microsoft/autogen) - A programming framework for building agentic AI applications.
   - [crewai](https://github.com/crewAIInc/crewAI) - A framework for orchestrating role-playing autonomous AI agents for collaborative task solving.


### PR DESCRIPTION
**llm-cost-profiler — Track, visualize, and optimize LLM API spending**

GitHub: https://github.com/BuildWithAbid/llm-cost-profiler
Install: pip install llm-spend-profiler
License: MIT
Python 3.9+, zero dependencies

Wraps OpenAI and Anthropic clients transparently to log every API call to local SQLite. Provides CLI commands to break down spend by feature, detect retry waste, context bloat, duplicate calls, and model downgrade opportunities. All data stays local.