### PR TITLE
Add better-fullstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,7 @@ _Libraries for building command-line applications._
 _Useful CLI-based tools for productivity._
 
 - Productivity Tools
+  - [better-fullstack](https://github.com/Marve10s/Better-Fullstack) - End-to-end fullstack scaffolding across TypeScript, Rust, Python & Go — code ready for you or your AI agent.
   - [cookiecutter](https://github.com/cookiecutter/cookiecutter) - A command-line utility that creates projects from cookiecutters (project templates).
   - [copier](https://github.com/copier-org/copier) - A library and command-line utility for rendering projects templates.
   - [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.


### PR DESCRIPTION
Adds better-fullstack to the CLI Tools > Productivity Tools section, alongside cookiecutter and copier.

better-fullstack is not written in Python, but it is one of the few scaffolding tools that natively supports Python project generation — including FastAPI, Django, SQLAlchemy, SQLModel, Pydantic, LangChain, and CrewAI. More Python-specific templates and tooling are actively being added.

- Open source (MIT), 356+ GitHub stars
- Available via npx/bun/pnpm/yarn
- Supports TypeScript, Rust, Python & Go ecosystems
- 270+ stack options across frontend, backend, database, auth, payments, AI, and more
- Presets for common stacks (t3, mern, pern, uniwind)
- Visual stack builder at better-fullstack.dev/new
- MCP support for AI-assisted project setup
- Preview mode to inspect your stack before generating
- https://better-fullstack.dev