### PR TITLE
Add Python Developer Tooling Handbook to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,10 @@ Where to discover learning resources or new Python libraries.
 - [Talk Python To Me](https://talkpython.fm/)
 - [The Real Python Podcast](https://realpython.com/podcasts/rpp/)
 
+## Websites
+
+- [Python Developer Tooling Handbook](https://pydevtools.com/) - Comprehensive guide to modern Python developer tools covering package management, linting, type checking, testing, and more.
+
 # Contributing
 
 Your contributions are always welcome! Please take a look at the [contribution guidelines](https://github.com/vinta/awesome-python/blob/master/CONTRIBUTING.md) first.


### PR DESCRIPTION
## What is pydevtools.com?

[pydevtools.com](https://pydevtools.com/) is the **Python Developer Tooling Handbook**, a comprehensive, freely available guide to modern Python developer tools. It covers:

- **Package management** (uv, pip, poetry, pdm, conda)
- **Linting and formatting** (Ruff, flake8, black)
- **Type checking** (mypy, ty, Pyright)
- **Testing** (pytest, tox, nox)
- **Virtual environments**, packaging, CI/CD, and more

The handbook follows the [Diataxis framework](https://diataxis.fr/) with tutorials, how-to guides, explanations, and reference pages, making it useful for both beginners setting up their first Python project and experienced developers evaluating modern tooling.

## Why add it?

The Resources section currently has Newsletters and Podcasts but no Websites subsection. pydevtools.com fills a gap as a curated, maintained resource specifically focused on Python developer tooling — a topic that's seen rapid change with tools like uv and Ruff gaining adoption. It would be valuable to the awesome-python community as a go-to reference for understanding the modern Python toolchain.

## Placement

Added under **Resources > Websites** (new subsection), following the pattern of the existing Newsletters and Podcasts subsections.