### PR TITLE
Add selectools – Python agent orchestration framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [hermes-agent](https://github.com/nousresearch/hermes-agent) - An adaptive AI agent framework that grows with you.
   - [langchain](https://github.com/langchain-ai/langchain) - Building applications with LLMs through composability.
   - [pydantic-ai](https://github.com/pydantic/pydantic-ai) - A Python agent framework for building generative AI applications with structured schemas.
+  - [selectools](https://github.com/johnnichev/selectools) - A Python agent framework for building composable AI applications with structured tool calling, HITL via generators, and 50+ built-in evaluators. Drag-and-drop visual builder at selectools.dev.
   - [TradingAgents](https://github.com/TauricResearch/TradingAgents) - A multi-agents LLM financial trading framework.
 - Data Layer
   - [instructor](https://github.com/567-labs/instructor) - A library for extracting structured data from LLMs, powered by Pydantic.


### PR DESCRIPTION
Adding selectools, a production-grade Python agent framework. 15+ months active, 4,612 tests at 95% coverage, pre-launch security audit with 9 critical fixes documented. Standalone framework (not a wrapper), addresses the "every agent framework has a different DSL" problem using plain Python + generators. Production deployments on 3 codebases.

Install: pip install selectools
Visual builder: https://selectools.dev/builder
GitHub: https://github.com/johnnichev/selectools