### PR TITLE
Add agent-brain to AI and Agents > Data Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
 - Data Layer
   - [instructor](https://github.com/567-labs/instructor) - A library for extracting structured data from LLMs, powered by Pydantic.
   - [llama-index](https://github.com/run-llama/llama_index) - A data framework for your LLM application.
+  - [agent-brain](https://github.com/kaderosio/agent-brain) - A 7-layer cognitive memory system for AI agents with perception gating, forgetting curves, and predictive alerts.
   - [mem0](https://github.com/mem0ai/mem0) - An intelligent memory layer for AI agents enabling personalized interactions.
 - Pre-trained Models and Inference
   - [diffusers](https://github.com/huggingface/diffusers) - A library that provides pre-trained diffusion models for generating and editing images, audio, and video.


### PR DESCRIPTION
## What is agent-brain?

[agent-brain](https://github.com/kaderosio/agent-brain) is a 7-layer cognitive memory system for AI agents with perception gating, forgetting curves, and predictive alerts. No LLM required.

### Why it belongs in Data Layer

Agent Brain provides the persistent memory and data infrastructure layer for AI agents, similar to how mem0 and llama-index serve as data layers. It uses PostgreSQL + pgvector for storage, sentence-transformers for embeddings, and spaCy for NLP — all without requiring an LLM.

- **GitHub:** https://github.com/kaderosio/agent-brain
- **License:** AGPLv3
- **Language:** Python (100%)
- **Framework:** FastAPI
- **Active:** Yes, v1.0.0 released April 2026

### Quality criteria
- Python-first: 100% Python codebase
- Active: Commits within the last 12 months
- Documented: README with examples and API documentation
- Unique: Only cognitive memory system with 7-layer architecture, perception gating, and forgetting curves without LLM dependency

Entry follows the standard format and is placed alphabetically in the Data Layer subsection.