### PR TITLE
Add Python Pro Hub to Resources > Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1108,6 +1108,10 @@ Where to discover learning resources or new Python libraries.
 - [Talk Python To Me](https://talkpython.fm/)
 - [The Real Python Podcast](https://realpython.com/podcasts/rpp/)
 
+- ## Websites
+
+- [Python Pro Hub](https://pythonprohub.com/) - Practical tutorials on Python errors, Django, Flask, data science with Pandas and Polars, and automation projects.
+
 # Contributing
 
 Your contributions are always welcome! Please take a look at the [contribution guidelines](https://github.com/vinta/awesome-python/blob/master/CONTRIBUTING.md) first.


### PR DESCRIPTION
Hi, I'd like to add Python Pro Hub to a new Websites section under Resources.

**URL:** https://pythonprohub.com

**What the site covers:**
- 170+ original articles published
- Python error fix guides (60+ errors with step-by-step solutions)
- Beginner to intermediate Python tutorials
- Django and Flask tutorials
- Data science with Pandas, Polars, and Matplotlib
- Automation and web scraping projects

All content is practical, example-driven, and original. Thank you for considering it.