### PR TITLE
Add cronviz — stdlib-only cron + systemd timer observability CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ _Libraries for generating project documentation._
 
 ## DevOps Tools
 
+- [cronviz](https://github.com/clementslowik/cronviz) - Unified cron and systemd timer observability CLI. Stdlib only, zero dependencies.
 _Software and libraries for DevOps._
 
 - Cloud Providers


### PR DESCRIPTION
[cronviz](https://github.com/clementslowik/cronviz) is a zero-dependency Python CLI that shows what's scheduled to run on a Linux server (cron jobs + systemd timers), when, and whether it ran last time.

- Pure stdlib, zero external dependencies
- Scans `/etc/crontab`, `/etc/cron.d/`, `/var/spool/cron/`, and `systemctl list-timers`
- Optional `--history` flag annotates with last-run timestamps from journalctl
- MIT licensed
- 48 unit tests