### PR TITLE
Add lumibot to Financial Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ _Libraries for data analysis._
 - Financial Data
   - [akshare](https://github.com/akfamily/akshare) - A financial data interface library, built for human beings!
   - [edgartools](https://github.com/dgunning/edgartools) - Library for downloading structured data from SEC EDGAR filings and XBRL financial statements.
+  - [lumibot](https://github.com/Lumiwealth/lumibot) - Algorithmic trading framework for backtesting and live deployment across stocks, options, crypto, futures, and forex.
   - [openbb](https://github.com/OpenBB-finance/OpenBB) - A financial data platform for analysts, quants and AI agents.
   - [yfinance](https://github.com/ranaroussi/yfinance) - Easy Pythonic way to download market and financial data from Yahoo Finance.
 


### PR DESCRIPTION
## What is lumibot?

[lumibot](https://github.com/Lumiwealth/lumibot) is an open-source Python framework (MIT license) for algorithmic trading backtesting and live deployment.

**PyPI**: `pip install lumibot`

## Acceptance Criteria: Hidden Gem

Lumibot qualifies as a **Hidden Gem** (1,333+ stars):

- **Solves a real pain point elegantly**: Write your trading strategy once and run it identically in backtesting and live production — no code changes needed between environments. This is the core problem every algo trader faces.
- **Multi-asset coverage**: Stocks, options, crypto, futures, and forex in a single framework, unlike most libraries that target only one asset class.
- **Multi-broker**: Alpaca, Interactive Brokers, Tradier, Schwab, and CCXT (100+ crypto exchanges). Most competitors support 1-2 brokers.
- **Built-in AI trading agent runtime**: First-class support for LLM-powered trading strategies.
- **Mature and established**: Repository created in 2021, 3+ years of consistent development, latest release v4.4.60 (April 2026).
- **Well-documented**: Full documentation site at lumibot.lumiwealth.com with examples, tutorials, and API reference.
- **Real-world usage**: Powers production trading strategies at Lumiwealth and used by the algo trading education community.

## Checklist

- [x] Entry follows the format: `- [pypi-name](github-url) - Description ending with period.`
- [x] Uses PyPI package name (`lumibot`) as display name
- [x] Placed in appropriate category: **Data Analysis > Financial Data**
- [x] Alphabetical order maintained (between `edgartools` and `openbb`)
- [x] Project is active (commits within last 12 months)
- [x] Repository is 3+ years old
- [x] Clear README with examples
- [x] Not a duplicate (searched list and previous PRs)
- [x] Single project per PR
- [x] Python-first (100% Python codebase)