### PR TITLE
Add meridian-mcp-deploy to Developer Tools > DevOps Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ _Libraries for generating project documentation._
 **DevOps**
 
 ## DevOps Tools
+Add entry under DevOps Tools section. Format: `- [meridian-mcp-deploy](https://github.com/meridianmindx/meridian-mcp-deploy) - MCP server deployment framework with automated provisioning and configuration.`
 
 _Software and libraries for DevOps._
 


### PR DESCRIPTION
This PR adds meridian-mcp-deploy to the Developer Tools > DevOps Tools section.

- **Tool:** meridian-mcp-deploy
- **Purpose:** See https://github.com/meridianmindx/meridian-mcp-deploy
- Maintainers: feel free to adjust formatting.
