### PR TITLE
Add meridian-crewai-deploy-orchestrator to AI & ML > AI and Agents > Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ An opinionated list of Python frameworks, libraries, tools, and resources.
 **AI & ML**
 
 ## AI and Agents
+Add to Orchestration subcategory alongside crewai. Format: `- [meridian-crewai-deploy-orchestrator](https://github.com/meridianmindx/meridian-crewai-deploy-orchestrator) - Deployment orchestration framework for CrewAI multi-agent systems.`
 
 _Libraries for building AI applications, LLM integrations, and autonomous agents._
 


### PR DESCRIPTION
This PR adds meridian-crewai-deploy-orchestrator to the AI & ML > AI and Agents > Orchestration section.

- **Tool:** meridian-crewai-deploy-orchestrator
- **Purpose:** See https://github.com/meridianmindx/meridian-crewai-deploy-orchestrator
- Maintainers: feel free to adjust formatting.
