### PR TITLE
Add NexusMemory - hybrid BM25 + semantic memory for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [instructor](https://github.com/567-labs/instructor) - A library for extracting structured data from LLMs, powered by Pydantic.
   - [llama-index](https://github.com/run-llama/llama_index) - A data framework for your LLM application.
   - [mem0](https://github.com/mem0ai/mem0) - An intelligent memory layer for AI agents enabling personalized interactions.
+  - [NexusMemory](https://github.com/Uhrenn/nexus-memory) - Hybrid BM25 + semantic memory for AI agents with self-improvement. 97.4% R@5 on LongMemEval.
 - Pre-trained Models and Inference
   - [diffusers](https://github.com/huggingface/diffusers) - A library that provides pre-trained diffusion models for generating and editing images, audio, and video.
   - [sglang](https://github.com/sgl-project/sglang) - A high-performance serving framework for large language models and multimodal models.


### PR DESCRIPTION
## Add NexusMemory

NexusMemory is a hybrid BM25 + semantic memory system for AI agents, featuring:

- **BM25 + ChromaDB + keyword overlap** via Reciprocal Rank Fusion (RRF)
- **97.4% Recall@5** on LongMemEval (500 questions) — without LLM reranking
- **Self-improvement** via use-count tracking and trust scoring
- **Nightly background synthesis** of lessons learned

Listed alphabetically alongside similar projects (mem0, llama-index) in the AI and Agents / Data Layer section.

Repo: https://github.com/Uhrenn/nexus-memory
PyPI: https://pypi.org/project/nexus-memory/