### PR TITLE
Add httptap

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,8 @@ _Libraries for debugging code._
 - Profiler
   - [py-spy](https://github.com/benfred/py-spy) - A sampling profiler for Python programs. Written in Rust.
   - [scalene](https://github.com/plasma-umass/scalene) - A high-performance, high-precision CPU, GPU, and memory profiler for Python.
+- Network
+  - [httptap](https://github.com/ozeranskii/httptap) - Dissects an HTTP request into DNS, TCP, TLS, wait, and transfer phases and renders the timings as a waterfall.
 - Others
   - [django-debug-toolbar](https://github.com/django-commons/django-debug-toolbar) - Display various debug information for Django.
   - [flask-debugtoolbar](https://github.com/pallets-eco/flask-debugtoolbar) - A port of the django-debug-toolbar to flask.

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ _Libraries for working with HTTP._
 
 - [aiohttp](https://github.com/aio-libs/aiohttp) - Asynchronous HTTP client/server framework for asyncio and Python.
 - [furl](https://github.com/gruns/furl) - A small Python library that makes parsing and manipulating URLs easy.
+- [httptap](https://github.com/ozeranskii/httptap) - Dissects an HTTP request into DNS, TCP, TLS, wait, and transfer phases and renders the timings as a waterfall.
 - [httpx](https://github.com/encode/httpx) - A next generation HTTP client for Python.
 - [requests](https://github.com/psf/requests) - HTTP Requests for Humans.
 - [urllib3](https://github.com/urllib3/urllib3) - A HTTP library with thread-safe connection pooling, file post support, sanity friendly.
@@ -646,8 +647,6 @@ _Libraries for debugging code._
 - Profiler
   - [py-spy](https://github.com/benfred/py-spy) - A sampling profiler for Python programs. Written in Rust.
   - [scalene](https://github.com/plasma-umass/scalene) - A high-performance, high-precision CPU, GPU, and memory profiler for Python.
-- Network
-  - [httptap](https://github.com/ozeranskii/httptap) - Dissects an HTTP request into DNS, TCP, TLS, wait, and transfer phases and renders the timings as a waterfall.
 - Others
   - [django-debug-toolbar](https://github.com/django-commons/django-debug-toolbar) - Display various debug information for Django.
   - [flask-debugtoolbar](https://github.com/pallets-eco/flask-debugtoolbar) - A port of the django-debug-toolbar to flask.


### PR DESCRIPTION
## Project

[httptap](https://github.com/ozeranskii/httptap)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

httptap solves one narrowly-scoped problem every backend developer eventually hits: *"my API is slow — where is the time going?"* It dissects a single HTTP request into DNS resolution, TCP connect, TLS handshake, server wait (TTFB), and body transfer phases, and renders the timings as a Rich waterfall, a compact single-line summary, or machine-readabl `key=value` metrics — whichever fits the context.

Signals of real-world maturity despite a modest star count (485 ⭐ in 6 months):

- **PyPI releases** (https://pypi.org/project/httptap/) with automated **SLSA v1.0 build provenance** and **Sigstore keyless signing** — verifiable via `gh attestation verify`.
- **OpenSSF Best Practices silver** (project 12474) and **OpenSSF Scorecard ~9/10**: pinned dependencies, strict token permissions, CodeQL SAST, signed releases.
- Full docs site at https://docs.httptap.dev — getting-started, API reference, troubleshooting, assurance case.
- Clean Python API (`httptap.HTTPTapAnalyzer`) with Protocol interfaces for DNS, TLS, timing, visualizer, and exporter — usable programmatically, not CLI-only.
- Production-oriented output modes: `--json` for post-hoc analysis, `--metrics-only` for log pipelines, per-step timings for redirect chains.
- curl-compatible flag aliases (`-X`, `-L`, `-k`, `-x`, `-H`) so it drops into existing shell scripts.

Repository is ~6 months old (created 2025-10-22) with consistent weekly commits and 30+ commits in the last 90 days.

## How It Differs

Existing entries in *HTTP Clients* (`aiohttp`, `httpx`, `requests`, `urllib3`, `furl`) are general-purpose libraries for issuing requests — none break a request down into per-phase timings. Existing entries in
*Debugging Tools* (`py-spy`, `scalene`, `pudb`, etc.) profile CPU, memory, or control flow of Python code — none profile the network phases of an HTTP exchange.

httptap fills the gap between these two categories: it is a diagnostic / debugging tool specifically for HTTP request latency (DNS → TCP → TLS → TTFB → transfer), which is a recurring source of production
incidents that general HTTP clients cannot diagnose and general profilers cannot see. Closest conceptual sibling outside Python is `httpstat` (a curl wrapper) or `curl -w`, both non-Python and without a library
API.

This is why it is proposed under **Debugging Tools → Network** (new subcategory) rather than HTTP Clients.