### PR TITLE
Add clawra-engine: AI agent framework with autonomous evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [trailofbits-skills](https://github.com/trailofbits/skills) - Python-friendly security skills for auditing, testing, and safer backend development.
 - Orchestration
   - [autogen](https://github.com/microsoft/autogen) - A programming framework for building agentic AI applications.
+  - [clawra-engine](https://github.com/wu-xiaochen/clawra-engine) - A framework for building AI agents with autonomous evolution, knowledge graphs, and neuro-symbolic reasoning.
   - [crewai](https://github.com/crewAIInc/crewAI) - A framework for orchestrating role-playing autonomous AI agents for collaborative task solving.
   - [dspy](https://github.com/stanfordnlp/dspy) - A framework for programming, not prompting, language models.
   - [hermes-agent](https://github.com/nousresearch/hermes-agent) - An adaptive AI agent framework that grows with you.


### PR DESCRIPTION
## Add clawra-engine

**Project:** [wu-xiaochen/clawra-engine](https://github.com/wu-xiaochen/clawra-engine)

**Description:** Clawra is a neuro-symbolic AI agent framework that autonomously learns rules from text (no more prompt engineering), featuring an 8-stage evolution loop, GraphRAG hybrid retrieval, and MCP server for Claude Code integration.

**Why it's awesome:**
- Self-evolving: AI learns rules from text instead of hardcoded prompts
- 8-stage evolution loop: perceive → learn → reason → execute → evaluate → drift detect → revise → update
- Symbolic logic blocks LLM hallucinations on safety-critical decisions
- AST-level math sandbox prevents DoS attacks from exponential math
- MCP server for seamless Claude Code integration
- 433 tests, MIT license

**Category:** AI and Agents

**Alphabetical order:** ✅ (placed between autogen and crewai)