### PR TITLE
Add fxmacrodata to Financial Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ _Libraries for data analysis._
 - Financial Data
   - [akshare](https://github.com/akfamily/akshare) - A financial data interface library, built for human beings!
   - [edgartools](https://github.com/dgunning/edgartools) - Library for downloading structured data from SEC EDGAR filings and XBRL financial statements.
+  - [fxmacrodata](https://github.com/fxmacrodata/fxmacrodata) - Real-time forex macroeconomic data from central bank announcements for 18 currencies.
   - [lumibot](https://github.com/Lumiwealth/lumibot) - Algorithmic trading framework for backtesting and live deployment across stocks, options, crypto, futures, and forex.
   - [openbb](https://github.com/OpenBB-finance/OpenBB) - A financial data platform for analysts, quants and AI agents.
   - [yfinance](https://github.com/ranaroussi/yfinance) - Easy Pythonic way to download market and financial data from Yahoo Finance.


### PR DESCRIPTION
Adds [fxmacrodata](https://github.com/fxmacrodata/fxmacrodata) to the **Data Analysis → Financial Data** section.

## About

`fxmacrodata` is a Python client library for the FXMacroData API, providing real-time forex macroeconomic data sourced directly from central bank announcements across 18 currencies.

- **PyPI**: https://pypi.org/project/fxmacrodata/
- **GitHub**: https://github.com/fxmacrodata/fxmacrodata
- **API docs**: https://fxmacrodata.com/api-docs

The library covers policy rates, inflation, employment, GDP, trade balance, and more — all from official central bank sources.