### PR TITLE
Add SlothDB to Database section

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ _Databases implemented in Python._
 - [chromadb](https://github.com/chroma-core/chroma) - An open-source embedding database for building AI applications with embeddings and semantic search.
 - [duckdb](https://github.com/duckdb/duckdb) - An in-process SQL OLAP database management system; optimized for analytics and fast queries, similar to SQLite but for analytical workloads.
 - [pickledb](https://github.com/patx/pickledb) - A simple and lightweight key-value store for Python.
+- [slothdb](https://github.com/SouravRoy-ETL/slothdb) - An embedded analytical database engine with GPU acceleration. Query CSV, Parquet, JSON, Excel with SQL. Zero dependencies.
 - [tinydb](https://github.com/msiemens/tinydb) - A tiny, document-oriented database.
 - [ZODB](https://github.com/zopefoundation/ZODB) - A native object database for Python. A key-value and object graph database.
 


### PR DESCRIPTION
## Add SlothDB

[SlothDB](https://github.com/SouravRoy-ETL/slothdb) is an embedded analytical database engine with Python bindings (`pip install slothdb`).

**Why it belongs here:**
- Embedded OLAP database like DuckDB (already listed), but with GPU acceleration
- Python API with pandas integration (`result.fetchdf()`)
- Query CSV, Parquet, JSON, Excel files directly with SQL
- Zero external dependencies
- MIT licensed

```python
import slothdb
db = slothdb.connect()
result = db.sql("SELECT * FROM 'data.csv' WHERE region = 'US'")
df = result.fetchdf()  # pandas DataFrame
```

**Placement:** Database section, alphabetical order after pickledb.