### PR TITLE
Add `respx` library to Mock section

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ _Libraries for testing codebases and generating test data._
   - [mock](https://docs.python.org/3/library/unittest.mock.html) - (Python standard library) A mocking and patching library.
   - [mocket](https://github.com/mindflayer/python-mocket) - A socket mock framework with gevent/asyncio/SSL support.
   - [responses](https://github.com/getsentry/responses) - A utility library for mocking out the requests Python library.
+  - [respx](https://github.com/lundberg/respx) - Mock HTTPX with awesome request patterns and response side effects.
   - [vcrpy](https://github.com/kevin1024/vcrpy) - Record and replay HTTP interactions on your tests.
 - Object Factories
   - [factory_boy](https://github.com/FactoryBoy/factory_boy) - A test fixtures replacement for Python.


### PR DESCRIPTION
## Project

[respx](https://github.com/lundberg/respx?tab=readme-ov-file) - Mock HTTPX with awesome request patterns and response side effects.

## Why This Project Is Awesome

- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

## How It Differs

- Test framework agnostic
- Like **responses** for **requests**, but for the *"next gen."* http library **httpx**

