### PR TITLE
Add issue-dash — self-hosted GitHub Issues dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,7 @@ _Software and libraries for DevOps._
   - [borg](https://github.com/borgbackup/borg) - A deduplicating archiver with compression and encryption.
   - [chaostoolkit](https://github.com/chaostoolkit/chaostoolkit) - A Chaos Engineering toolkit & Orchestration for Developers.
   - [pre-commit](https://github.com/pre-commit/pre-commit) - A framework for managing and maintaining multi-language pre-commit hooks.
+  - [issue-dash](https://github.com/GiulioSavini/issue-dash) - A self-hosted GitHub Issues dashboard with AI triage suggestions and CI failure analysis.
 
 ## Distributed Computing
 


### PR DESCRIPTION
Adds [issue-dash](https://github.com/GiulioSavini/issue-dash) under **DevOps Tools → Other**.

A self-hosted, read-only GitHub Issues dashboard written in Python. Groups open issues by urgency/triage/WIP, surfaces CI failures on your PRs, and generates AI bullet-point suggestions via GitHub Models (same token, free for all accounts). Docker-ready, zero dependencies beyond Python + the `gh` CLI.

```bash
REPO=owner/repo python3 dashboard.py --html out.html --suggest
```