### PR TITLE
Add `django-modern-rest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ _Traditional full stack web frameworks. Also see [Web APIs](#web-apis)._
 _Libraries for building RESTful and GraphQL APIs._
 
 - Django
+  - [django-modern-rest](https://github.com/wemake-services/django-modern-rest) - Modern REST with speed, types, async, `msgspec`, `pydantic` and other goodies!
   - [django-ninja](https://github.com/vitalik/django-ninja) - Fast, Django REST framework based on type hints and Pydantic.
   - [django-rest-framework](https://github.com/encode/django-rest-framework) - A powerful and flexible toolkit to build web APIs.
   - [strawberry-django](https://github.com/strawberry-graphql/strawberry-django) - Strawberry GraphQL integration with Django.


### PR DESCRIPTION
https://github.com/vinta/awesome-python/blob/master/CONTRIBUTING.md#3-hidden-gem

## Project

Hi 👋 
My name is Nikita Sobolev, I am a CPython core developer, Django Software Foundation member, [`django-stubs`](https://github.com/typeddjango/django-stubs) main maintainer, and today I want to present my new Django project :)

[django-modern-rest](https://github.com/wemake-services/django-modern-rest)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

- [x] Exceptional quality despite fewer stars (100-500 stars preferred; < 100 requires strong justification)
  I belive that `django-modern-rest` has an exceptional quality. It is the [fastest tool](https://django-modern-rest.readthedocs.io/en/latest/pages/deep-dive/performance.html) on the market in its category. It supports more types of models that anybody else: we support `msgspec`, `attrs`, `pydantic`, `dataclasses`, `TypeDict`, `NamedTuple`, etc. We also supports multiple [streaming formats](https://django-modern-rest.readthedocs.io/en/latest/pages/streaming/common.html): SSE and JsonLines, when none other existing frameworks do. We bundle auth with [JWT tokens](https://django-modern-rest.readthedocs.io/en/latest/pages/auth/jwt.html), while `ninja` and `drf` do not. We have an amazing OpenAPI schema generation, it documents everything, this is the main design goal, no other Python framework does anything similar. We support all major type-checkers (`mypy`, `pyright`, `pyrefly`, `ty` support is incomming) in strict modes, while `ninja` and `drf` - do not. We [support LLMs](https://django-modern-rest.readthedocs.io/en/latest/pages/getting-started.html#llms-support) as first-class citizens, providing skills, contexts, learning paths, etc. We also have a lot of DX features like `polyfactory` and `tracecov` integrations, which make the dev experience a lot better.
  We have 1100+ stars, which is not a lot, but it is not few :)
- [x] Solves niche problems elegantly
  This is a very nice way to build your REST APIs in Django.
- [x] Strong recommendation from experienced developers
  We have several testimonials from CPython core devs (myself included), Django core dev, schemathesis author: https://github.com/wemake-services/django-modern-rest/#testimonials
- [x] Must demonstrate real-world usage (not a project published last week)
  Yes, addoption does exist, still not VERY wide. See https://github.com/kondratevdev/awesome-django-modern-rest
- [x] Repository must be at least 6 months old with consistent activity
  Yes, first commit was in October 2025 https://github.com/wemake-services/django-modern-rest/commit/af5b991ef8a8ae064dfb7550e34a6bf43b2f6615
- [x] Must include compelling justification in PR description
  I hope that I nailed it :)

## How It Differs

See above :)
