### PR TITLE
docs(ai-agents): add ag2 to AI Agents Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [sentry-skills](https://github.com/getsentry/skills) - Python-focused engineering skills for code review, debugging, and backend workflows.
   - [trailofbits-skills](https://github.com/trailofbits/skills) - Python-friendly security skills for auditing, testing, and safer backend development. Also [skills-curated](https://github.com/trailofbits/skills-curated).
 - Orchestration
+  - [ag2](https://github.com/ag2ai/ag2) - An open-source AgentOS for multi-agent orchestration and building agentic AI systems.
   - [autogen](https://github.com/microsoft/autogen) - A programming framework for building agentic AI applications.
   - [bub](https://github.com/bubbuild/bub) - A lightweight, hook-first Python framework for channel-native agents that live alongside people.
   - [crewai](https://github.com/crewAIInc/crewAI) - A framework for orchestrating role-playing autonomous AI agents for collaborative task solving.


### PR DESCRIPTION
## Project

[ag2](https://github.com/ag2ai/ag2)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [x] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [ ] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

AG2 (positioned as "the Open-Source AgentOS") is one of the primary Python frameworks for building and orchestrating multi-agent AI systems. It has 4.4k+ GitHub stars, a published PyPI package (`ag2`), dedicated documentation at [docs.ag2.ai](https://docs.ag2.ai/latest/), and active, frequent releases.

AG2 originated as the AutoGen codebase and continued as an independent, community-governed project under the `ag2ai` organization from late 2024 onward, now with its own maintainers, release line, and roadmap. It pioneered several patterns that are now standard across the agent-framework ecosystem (GroupChat for multi-agent conversations, structured human-in-the-loop workflows, tool/function-calling abstractions across LLM providers), and remains a go-to choice for teams specifically building multi-agent conversational systems in Python.

The project is also actively evolving: the recent [AG2 Beta](https://docs.ag2.ai/0.12.0/docs/beta/motivation/) introduces an event-driven architecture designed around emerging agent standards — native support for the Model Context Protocol (MCP), Agent2Agent (A2A), and AG-UI — plus stronger context and memory primitives, new multi-agent coordination patterns, and cleaner integration with Text UI, web, ambient, and background runtimes. AG2 Beta agents remain backward-compatible with AG2 multi-agent interaction patterns from day one, enabling gradual adoption.

