### PR TITLE
Add deepalpha to Financial Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ _Libraries for data analysis._
   - [akshare](https://github.com/akfamily/akshare) - A financial data interface library, built for human beings!
   - [edgartools](https://github.com/dgunning/edgartools) - Library for downloading structured data from SEC EDGAR filings and XBRL financial statements.
   - [lumibot](https://github.com/Lumiwealth/lumibot) - Algorithmic trading framework for backtesting and live deployment across stocks, options, crypto, futures, and forex.
+- [deepalpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot for Bybit with walk-forward validated ML models and 72 features.
   - [openbb](https://github.com/OpenBB-finance/OpenBB) - A financial data platform for analysts, quants and AI agents.
   - [yfinance](https://github.com/ranaroussi/yfinance) - Easy Pythonic way to download market and financial data from Yahoo Finance.
 


### PR DESCRIPTION
## Add deepalpha

Added [deepalpha](https://github.com/stefanoviana/deepalpha) to the **Financial Data** section.

**deepalpha** is an AI crypto trading bot for Bybit with:
- Walk-forward validated ML models (70.9% accuracy)
- LightGBM + XGBoost ensemble with 72 ML features
- MIT licensed, available on PyPI (`pip install deepalpha`)

Website: https://deepalphabot.com