### PR TITLE
Add structkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,7 @@ _Useful CLI-based tools for productivity._
   - [cookiecutter](https://github.com/cookiecutter/cookiecutter) - A command-line utility that creates projects from cookiecutters (project templates).
   - [copier](https://github.com/copier-org/copier) - A library and command-line utility for rendering projects templates.
   - [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
+  - [structkit](https://github.com/httpdss/structkit) - A command-line tool that scaffolds project files and directories from a YAML configuration.
   - [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
   - [tmuxp](https://github.com/tmux-python/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.
   - [xonsh](https://github.com/xonsh/xonsh/) - A Python-powered shell. Full-featured and cross-platform.


### PR DESCRIPTION
## Project

[StructKit](https://github.com/httpdss/structkit)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add structkit`
- [x] Entry format: `- [structkit](https://github.com/httpdss/structkit) - A command-line tool that scaffolds project files and directories from a YAML configuration.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

StructKit sits in a gap that the established scaffolders don't fill cleanly. Cookiecutter requires a nested template repo layout and Python+Jinja knowledge. Yeoman is JS-only. PyScaffold is locked to the Python-package use case. StructKit lets you describe an entire project — files, directories, contents, permissions, even pre/post-generation shell hooks — in a single readable YAML file, regardless of the target language.

Differentiating capabilities:
- Single-file YAML config; no nested template directory to learn
- Remote content fetching from any HTTP source (GitHub repos, Gists, internal registries) referenced inline in the YAML
- Jinja2-style template variables and project-wide variable injection
- Lifecycle hooks for running formatters, installers, or git init after generation
- Dry-run preview mode that prints the planned tree without writing
- Language-agnostic — used today for Python, Terraform, Next.js, Kubernetes, and microservice templates
- MIT licensed, actively maintained, v3.0.0

## How It Differs

- **vs cookiecutter** - One readable YAML file instead of a template repo with nested directories. Remote content fetching built in. No requirement to learn a separate Cookiecutter template layout.
- **vs copier** - Simpler config model focused purely on initial scaffolding. Copier's strength is project-update workflows; StructKit stays small and composable for the generation step alone.
- **vs yeoman** - Language-agnostic, no Node.js dependency, no generator authoring framework to learn.
- **vs pyscaffold** - Not constrained to the Python-package layout; works for any project type from a Terraform module to a microservice cluster.