### PR TITLE
Add pytest-cloudreport

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ _Libraries for testing codebases and generating test data._
   - [locust](https://github.com/locustio/locust) - Scalable user load testing tool written in Python.
   - [playwright-python](https://github.com/microsoft/playwright-python) - Python version of the Playwright testing and automation library.
   - [pyautogui](https://github.com/asweigart/pyautogui) - PyAutoGUI is a cross-platform GUI automation Python module for human beings.
+  - [pytest-cloudreport](https://github.com/ahmad212o/pytest-cloudreport) - A pytest plugin for automatic flaky test detection and CI analytics, with local HTML reports and an optional cloud dashboard.
   - [schemathesis](https://github.com/schemathesis/schemathesis) - A tool for automatic property-based testing of web applications built with Open API / Swagger specifications.
   - [selenium](https://github.com/SeleniumHQ/selenium) - Python bindings for [Selenium](https://selenium.dev/) [WebDriver](https://selenium.dev/documentation/webdriver/).
 - Mock


### PR DESCRIPTION
## Project
[pytest-cloudreport](https://github.com/ahmad212o/pytest-cloudreport)

## Checklist
- [x] One project per PR
- [x] PR title format: `Add pytest-cloudreport`
- [x] Entry format: `- [pytest-cloudreport](https://github.com/ahmad212o/pytest-cloudreport) - A pytest plugin for automatic flaky test detection and CI analytics, with local HTML reports and an optional cloud dashboard.`
- [x] Description is concise and short

## Why This Project Is Awesome
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain: pytest-cloudreport is the only pytest-native plugin that combines automatic flaky test detection with CI trend analytics in a single zero-config tool. Free local HTML report out of the box with no account required. Already listed on the official pytest plugin directory and actively maintained on PyPI.

## How It Differs
Existing testing tools in the list focus on coverage, mocking, and assertions. pytest-cloudreport fills a different gap — identifying unreliable tests across runs and tracking CI stability over time. No other listed tool does this natively for pytest teams.