### PR TITLE
Add atomadic-forge to Code Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ _Interactive Python interpreters (REPL)._
 _Tools of static analysis, linters and code quality checkers. Also see [awesome-static-analysis](https://github.com/analysis-tools-dev/static-analysis)._
 
 - Code Analysis
+  - [atomadic-forge](https://github.com/atomadictech/atomadic-forge) - Architecture compiler enforcing 5-tier monadic dependency rules on Python codebases. Classifies files, detects tier violations, and certifies 0-100.
   - [code2flow](https://github.com/scottrogowski/code2flow) - Turn your Python and JavaScript code into DOT flowcharts.
   - [prospector](https://github.com/prospector-dev/prospector) - A tool to analyze Python code.
   - [repowise](https://github.com/repowise-dev/repowise) - Codebase intelligence that indexes repos into dependency graphs, git history, and auto-generated docs with dead code detection.


### PR DESCRIPTION
**Checklist:**
- [x] This tool/library is tested and documented
- [x] Link works — https://github.com/atomadictech/atomadic-forge
- [x] Entry is in alphabetical order (before code2flow)
- [x] Added in the correct section: Code Analysis

**About the tool:**

[atomadic-forge](https://github.com/atomadictech/atomadic-forge) is a Python architecture compiler that enforces strict 5-tier monadic dependency rules. Unlike pylint (style) or bandit (security), it focuses specifically on **dependency direction** and **tier compliance** — classifying every file into one of five architectural tiers (constants → functions → composites → features → orchestration) and certifying structural integrity on a 0-100 scale.

- `forge recon` — classify codebase into 5 tiers
- `forge wire` — import-direction linter (detects upward imports)
- `forge certify` — architecture integrity score 0-100
- `forge auto` — automated refactor to enforce monadic layout

Install: `pip install atomadic-forge`
Docs: https://forge.atomadic.tech