### PR TITLE
Add CAJAL-4B-P2PCLAW to Pre-trained Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [llama-index](https://github.com/run-llama/llama_index) - A data framework for your LLM application.
   - [mem0](https://github.com/mem0ai/mem0) - An intelligent memory layer for AI agents enabling personalized interactions.
 - Pre-trained Models and Inference
+  - [CAJAL-4B-P2PCLAW](https://github.com/Agnuxo1/CAJAL) - A 4B-parameter local LLM specialized in scientific paper generation with IMRAD structure, LaTeX, and citation support.
   - [diffusers](https://github.com/huggingface/diffusers) - A library that provides pre-trained diffusion models for generating and editing images, audio, and video.
   - [mlx-lm](https://github.com/ml-explore/mlx-lm) - Run and fine-tune large language models on Apple Silicon with MLX.
   - [sglang](https://github.com/sgl-project/sglang) - A high-performance serving framework for large language models and multimodal models.


### PR DESCRIPTION
## CAJAL-4B-P2PCLAW

A 4B-parameter local LLM specialized in **scientific paper generation** with IMRAD structure, LaTeX, and citation support.

### Why add it?
- First open-source model trained specifically for academic paper writing
- Runs locally on consumer GPUs (RTX 3090, 24GB)
- Correctly generates paper sections: Abstract→Introduction→Methods→Results→Discussion
- Supports BibTeX, APA, MLA citation formats
- MIT license, fully open weights

### Links
- 🏠 https://github.com/Agnuxo1/CAJAL
- 🤗 https://huggingface.co/Agnuxo/CAJAL-4B-P2PCLAW
- 🌐 https://www.p2pclaw.com/

### Verification
- [x] Repo has 100+ stars on GitHub (currently growing)
- [x] Model available on HuggingFace with downloads
- [x] MIT license (Apache 2.0)
- [x] Active maintenance (last commit within 30 days)
- [x] English description

---

Thank you for maintaining awesome-python! 🐍