### PR TITLE
Add burner-bouncer to email libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ _Libraries for sending and parsing email, and mail server management._
 
 - [modoboa](https://github.com/modoboa/modoboa) - A mail hosting and management platform including a modern Web UI.
 - [yagmail](https://github.com/kootenpv/yagmail) - Yet another Gmail/SMTP client.
+- [burner-bouncer](https://github.com/grocerysushi/burner-bouncer) - Zero-dependency disposable email detector
 
 **Database & Storage**
 


### PR DESCRIPTION
Added burner-bouncer to the list of email libraries.

## Project

[burner-bouncer](https://github.com/grocerysushi/burner-bouncer)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add burner-bouncer`
- [x] Entry format: [burner-bouncer](https://github.com/grocerysushi/burner-bouncer) - Zero-dependency disposable email detector.
- [x] Description is concise and short

## Why This Project Is Awesome
burner-bouncer solves a common but overlooked problem — disposable email detection — with zero runtime dependencies, no API calls, and a bundled blocklist of 629 real domains. Ships as both an npm package (TypeScript, ESM + CJS) and a Python package with an identical API.

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

## How It Differs
Most email validation libraries focus on format checking. burner-bouncer specifically targets disposable/burner domains and is the only library to ship the same API in both JavaScript and Python backed by a single shared community-maintained blocklist.

If similar entries exist, what makes this one unique?
