### PR TITLE
Use HTTPS for JSON Schema link

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ _Libraries for data analysis._
 _Libraries for validating data. Used for forms in many cases._
 
 - [cerberus](https://github.com/pyeve/cerberus) - A lightweight and extensible data validation library.
-- [jsonschema](https://github.com/python-jsonschema/jsonschema) - An implementation of [JSON Schema](http://json-schema.org/) for Python.
+- [jsonschema](https://github.com/python-jsonschema/jsonschema) - An implementation of [JSON Schema](https://json-schema.org/) for Python.
 - [pandera](https://github.com/unionai-oss/pandera) - A data validation library for dataframes, with support for pandas, polars, and Spark.
 - [pydantic](https://github.com/pydantic/pydantic) - Data validation using Python type hints.
 - [voluptuous](https://github.com/alecthomas/voluptuous) - A Python data validation library primarily intended for validating data from untrusted sources.


### PR DESCRIPTION
## Project

[jsonschema](https://github.com/python-jsonschema/jsonschema)

## Checklist

- [x] One project per PR
- [x] Entry format remains `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Change

This updates the JSON Schema reference link from `http://json-schema.org/` to `https://json-schema.org/`. The HTTPS endpoint returns `200` and serves the same JSON Schema site.

## Verification

- `git diff --check`
- `Invoke-WebRequest https://json-schema.org/` returned `200`

Note: `uv run pytest website/tests -q` was attempted from this fresh clone, but local dependency installation failed on Windows with `Access is denied` while installing `httpx==0.28.1`.