### PR TITLE
Add bernstein to AI and Agents > Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
 - Orchestration
   - [ag2](https://github.com/ag2ai/ag2) - An open-source AgentOS for multi-agent orchestration and building agentic AI systems.
   - [autogen](https://github.com/microsoft/autogen) - A programming framework for building agentic AI applications.
+  - [bernstein](https://github.com/sipyourdrink-ltd/bernstein) - A deterministic Python orchestrator for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40+ more) with parallel git worktrees and an HMAC-signed audit chain.
   - [bub](https://github.com/bubbuild/bub) - A lightweight, hook-first Python framework for channel-native agents that live alongside people.
   - [crewai](https://github.com/crewAIInc/crewAI) - A framework for orchestrating role-playing autonomous AI agents for collaborative task solving.
   - [dspy](https://github.com/stanfordnlp/dspy) - A framework for programming, not prompting, language models.


### PR DESCRIPTION
Adds bernstein under AI and Agents > Orchestration, alphabetically between `autogen` and `bub`.

It is a Python multi-agent orchestrator distinct from the existing entries: deterministic scheduling (no LLM in the control loop) for parallel CLI coding agents — Claude Code, Codex, Gemini CLI and others — using git worktrees and signed audit logs. Production usage and Hidden Gem fit per CONTRIBUTING.md (120 stars, Apache-2.0, 6+ months active, on PyPI as `bernstein`).