### PR TITLE
fix: remove duplicate ruff entry from Code Linters section

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,10 +603,11 @@ _Tools of static analysis, linters and code quality checkers. Also see [awesome-
   - [bandit](https://github.com/PyCQA/bandit) - A tool designed to find common security issues in Python code.
   - [flake8](https://github.com/PyCQA/flake8) - A wrapper around `pycodestyle`, `pyflakes` and McCabe.
     - [awesome-flake8-extensions](https://github.com/DmytroLitvinov/awesome-flake8-extensions)
-  - [pylint](https://github.com/pylint-dev/pylint) - A fully customizable source code analyzer.
-  
+ - [pylint](https://github.com/pylint-dev/pylint) - A fully customizable source code analyzer.
+- Code Formatters
   - [black](https://github.com/psf/black) - The uncompromising Python code formatter.
   - [isort](https://github.com/PyCQA/isort) - A Python utility / library to sort imports.
+  - [ruff](https://github.com/astral-sh/ruff) - An extremely fast Python linter and code formatter.
   
 - Refactoring
   - [rope](https://github.com/python-rope/rope) - Rope is a python refactoring library.

--- a/README.md
+++ b/README.md
@@ -604,8 +604,7 @@ _Tools of static analysis, linters and code quality checkers. Also see [awesome-
   - [flake8](https://github.com/PyCQA/flake8) - A wrapper around `pycodestyle`, `pyflakes` and McCabe.
     - [awesome-flake8-extensions](https://github.com/DmytroLitvinov/awesome-flake8-extensions)
   - [pylint](https://github.com/pylint-dev/pylint) - A fully customizable source code analyzer.
-  - [ruff](https://github.com/astral-sh/ruff) - An extremely fast Python linter and code formatter.
-- Code Formatters
+  
   - [black](https://github.com/psf/black) - The uncompromising Python code formatter.
   - [isort](https://github.com/PyCQA/isort) - A Python utility / library to sort imports.
   - [ruff](https://github.com/astral-sh/ruff) - An extremely fast Python linter and code formatter.
@@ -1158,3 +1157,5 @@ Your contributions are always welcome! Please take a look at the [contribution g
 ---
 
 If you have any question about this opinionated list, do not hesitate to contact [@vinta](https://x.com/vinta) on X (Twitter).
+
+

--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ _Tools of static analysis, linters and code quality checkers. Also see [awesome-
   
   - [black](https://github.com/psf/black) - The uncompromising Python code formatter.
   - [isort](https://github.com/PyCQA/isort) - A Python utility / library to sort imports.
-  - [ruff](https://github.com/astral-sh/ruff) - An extremely fast Python linter and code formatter.
+  
 - Refactoring
   - [rope](https://github.com/python-rope/rope) - Rope is a python refactoring library.
 - Type Checkers - [awesome-python-typing](https://github.com/typeddjango/awesome-python-typing)
@@ -1157,5 +1157,3 @@ Your contributions are always welcome! Please take a look at the [contribution g
 ---
 
 If you have any question about this opinionated list, do not hesitate to contact [@vinta](https://x.com/vinta) on X (Twitter).
-
-

--- a/README.md
+++ b/README.md
@@ -603,12 +603,11 @@ _Tools of static analysis, linters and code quality checkers. Also see [awesome-
   - [bandit](https://github.com/PyCQA/bandit) - A tool designed to find common security issues in Python code.
   - [flake8](https://github.com/PyCQA/flake8) - A wrapper around `pycodestyle`, `pyflakes` and McCabe.
     - [awesome-flake8-extensions](https://github.com/DmytroLitvinov/awesome-flake8-extensions)
- - [pylint](https://github.com/pylint-dev/pylint) - A fully customizable source code analyzer.
+  - [pylint](https://github.com/pylint-dev/pylint) - A fully customizable source code analyzer.
 - Code Formatters
   - [black](https://github.com/psf/black) - The uncompromising Python code formatter.
   - [isort](https://github.com/PyCQA/isort) - A Python utility / library to sort imports.
   - [ruff](https://github.com/astral-sh/ruff) - An extremely fast Python linter and code formatter.
-  
 - Refactoring
   - [rope](https://github.com/python-rope/rope) - Rope is a python refactoring library.
 - Type Checkers - [awesome-python-typing](https://github.com/typeddjango/awesome-python-typing)


### PR DESCRIPTION
## Problem
`ruff` was listed twice in the Code Analysis section:
- Under Code Linters
- Under Code Formatters

## Fix
Removed the duplicate entry from Code Linters.
"Ruff" is already listed under Code Formatters, where it belongs.