### PR TITLE
Add chunktuner library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ _Frameworks for Neural Networks and Deep Learning. Also see [awesome-deep-learni
 _Libraries for Machine Learning. Also see [awesome-machine-learning](https://github.com/josephmisiti/awesome-machine-learning#python)._
 
 - [catboost](https://github.com/catboost/catboost) - A fast, scalable, high performance gradient boosting on decision trees library.
+- [chunktuner](https://github.com/shantanu-deshmukh/chunktuner) - Auto-tune document chunking for RAG with benchmarked strategies, retrieval metrics, optional RAGAS evaluation, CLI, and MCP server.
 - [feature_engine](https://github.com/feature-engine/feature_engine) - sklearn compatible API with the widest toolset for feature engineering and selection.
 - [h2o](https://github.com/h2oai/h2o-3) - Open Source Fast Scalable Machine Learning Platform.
 - [lightgbm](https://github.com/lightgbm-org/LightGBM) - A fast, distributed, high performance gradient boosting framework.


### PR DESCRIPTION
Added chunktuner library for document chunking and evaluation.

## Project
Proposes adding PyPI package **[chunktuner](https://pypi.org/project/chunktuner/)** ([repo](https://github.com/shantanu-deshmukh/chunktuner))


[ChunkTuner](https://github.com/shantanu-deshmukh/chunktuner)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

## How It Differs
- **Actionable quality lever:** readers building LLM apps need more than model APIs; retrieval quality often dominates UX, and chunktuner makes chunking strategy selection **measurable** on their own documents.
- **Three integration modes:** library for services, **CLI** for automation, **MCP** for assistants—fits diverse Python practitioners in this list.

If similar entries exist, what makes this one unique?
