### PR TITLE
Add aegis-dq to Data Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ _Libraries for data extraction, transformation, and loading pipelines across mul
 
 _Libraries for validating data. Used for forms in many cases._
 
+- [aegis-dq](https://github.com/aegis-dq/aegis-dq) - An agentic data quality framework with LLM-powered diagnosis, root-cause analysis, and SQL auto-fix — 31 rule types, pluggable LLMs, DuckDB/BigQuery/Databricks adapters.
 - [cerberus](https://github.com/pyeve/cerberus) - A lightweight and extensible data validation library.
 - [jsonschema](https://github.com/python-jsonschema/jsonschema) - An implementation of [JSON Schema](https://json-schema.org/) for Python.
 - [pandera](https://github.com/unionai-oss/pandera) - A data validation library for dataframes, with support for pandas, polars, and Spark.


### PR DESCRIPTION
## Description

Adds [aegis-dq](https://github.com/aegis-dq/aegis-dq) to the **Data Validation** section.

**aegis-dq** is an open-source agentic data quality framework that goes beyond pass/fail validation — it uses an LLM pipeline (LangGraph) to diagnose *why* checks fail, trace root causes, and propose SQL fixes.

- Apache 2.0 license
- 31 rule types across completeness, uniqueness, validity, referential, statistical, ML anomaly
- Pluggable LLMs: Anthropic, OpenAI, Ollama (local), AWS Bedrock
- Warehouse adapters: DuckDB, Postgres, BigQuery, Databricks, Athena, Snowflake
- GitHub Action for CI/CD gates
- 601 tests, actively maintained

Placed alphabetically before `cerberus`.