### PR TITLE
Add dakera-py to AI and Agents > Data Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [pydantic-ai](https://github.com/pydantic/pydantic-ai) - A Python agent framework for building generative AI applications with structured schemas.
   - [TradingAgents](https://github.com/TauricResearch/TradingAgents) - A multi-agents LLM financial trading framework.
 - Data Layer
+  - [dakera-py](https://github.com/dakera-ai/dakera-py) - Official Python SDK for the Dakera self-hosted agent memory server, with async store/recall, session management, decay config, and full MCP integration.
   - [instructor](https://github.com/567-labs/instructor) - A library for extracting structured data from LLMs, powered by Pydantic.
   - [llama-index](https://github.com/run-llama/llama_index) - A data framework for your LLM application.
-  - [dakera-py](https://github.com/dakera-ai/dakera-py) - Official Python SDK for the Dakera self-hosted agent memory server, with async store/recall, session management, decay config, and full MCP integration.
   - [mem0](https://github.com/mem0ai/mem0) - An intelligent memory layer for AI agents enabling personalized interactions.
 - Pre-trained Models and Inference
   - [diffusers](https://github.com/huggingface/diffusers) - A library that provides pre-trained diffusion models for generating and editing images, audio, and video.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
 - Data Layer
   - [instructor](https://github.com/567-labs/instructor) - A library for extracting structured data from LLMs, powered by Pydantic.
   - [llama-index](https://github.com/run-llama/llama_index) - A data framework for your LLM application.
+  - [dakera-py](https://github.com/dakera-ai/dakera-py) - Official Python SDK for the Dakera self-hosted agent memory server, with async store/recall, session management, decay config, and full MCP integration.
   - [mem0](https://github.com/mem0ai/mem0) - An intelligent memory layer for AI agents enabling personalized interactions.
 - Pre-trained Models and Inference
   - [diffusers](https://github.com/huggingface/diffusers) - A library that provides pre-trained diffusion models for generating and editing images, audio, and video.


### PR DESCRIPTION
## dakera-py

[dakera-py](https://github.com/dakera-ai/dakera-py) is the official Python SDK for the Dakera self-hosted agent memory server.

**Why it fits the Data Layer subsection under AI and Agents:**
- Sits alongside mem0 as a production-grade agent memory solution, but with a self-hosted, privacy-first approach
- Async-first API for store/recall, session management, decay configuration, and namespace operations
- Designed for Python agent frameworks (LangChain, crewAI, autogen) that need persistent cross-session memory
- Connects to a self-hosted Dakera server that scores 87.8% on the LoCoMo long-term conversational memory benchmark

The Data Layer subsection is exactly the right place — dakera-py gives Python agents the persistent memory layer they need alongside vector DBs and llama-index.