### PR TITLE
Add beava to Data Ingestion / ETL → Real-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,8 @@ _Libraries for data extraction, transformation, and loading pipelines across mul
   - [lumibot](https://github.com/Lumiwealth/lumibot) - Algorithmic trading framework for backtesting and live deployment across stocks, options, crypto, futures, and forex.
   - [openbb](https://github.com/OpenBB-finance/OpenBB) - A financial data platform for analysts, quants and AI agents.
   - [yfinance](https://github.com/ranaroussi/yfinance) - Easy Pythonic way to download market and financial data from Yahoo Finance.
+- Real-time
+  - [beava](https://github.com/beava-dev/beava) - Real-time feature server for fraud detection, recommender systems, and LLM guardrails; define pipelines in Python and query live per-entity aggregates over HTTP or TCP.
 
 ### Data Validation
 


### PR DESCRIPTION
Adds beava under `Data Ingestion / ETL` as a new `Real-time` subcategory (peer to General / Financial Data).

```markdown
- Real-time
  - [beava](https://github.com/beava-dev/beava) - Real-time feature server for fraud detection, recommender systems, and LLM guardrails; define pipelines in Python and query live per-entity aggregates over HTTP or TCP.
```

## Hidden Gem

beava is one of the very few tools — and possibly the only Python-native OSS one today — that lets you build a real-time feature pipeline with no Kafka and no Flink in the loop. Events go straight into a single Rust binary; the hot path is optimized for sub-millisecond reads (in-memory state, custom framed TCP fast-path), and the next query reflects the push. User surface is Python (`@bv.event`, `@bv.table`, `bv.count(window="10m")`) — same shape as polars or pydantic-core, and `pip install beava` ships the server binary. Nothing else in the list fills this niche: `dlt` is batch ETL, `faststream` is an async broker client, and the Kafka+Flink+feature-store alternatives feel heavy for a fraud or LLM-guardrail signal that should be 15 lines of Python.

Honest about the timing: the public repo is 9 days old after a few months of stealth, so the 3-month consistent-activity bar isn't formally met. Submitting in case the niche feels worth a small exception — totally fair to ask me to come back in August, grateful for the consideration either way.
