### PR TITLE
Add github-to-human

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,6 +822,7 @@ _Useful CLI-based tools for productivity._
   - [tmuxp](https://github.com/tmux-python/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.
   - [xonsh](https://github.com/xonsh/xonsh/) - A Python-powered shell. Full-featured and cross-platform.
   - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A command-line program to download videos from YouTube and other video sites, a fork of youtube-dl.
+  - [github-to-human](https://github.com/nonlinearHuman/github-to-human) - AI-powered tool that translates GitHub repos into plain-language 3-step guides.
 - CLI Enhancements
   - [httpie](https://github.com/httpie/cli) - A command line HTTP client, a user-friendly cURL replacement.
   - [iredis](https://github.com/laixintao/iredis) - Redis CLI with autocompletion and syntax highlighting.


### PR DESCRIPTION
## Project

[github-to-human](https://github.com/nonlinearHuman/github-to-human)

## Checklist

- [x] One project per PR
- [x] PR title format: Add project-name
- [x] Entry format: - [project-name](url) - Description ending with period.
- [x] Description is concise and short

## Why This Project Is Awesome

- [x] **Industry Standard** - The go-to tool for a specific use case

github-to-human is an AI-powered CLI tool that translates any GitHub repository into plain-language 3-step guides. It helps developers quickly understand what a project does and how to get started, without having to read through complex README files. Supports GLM, OpenAI, DeepSeek, and MiniMax.