### PR TITLE
Add click-to-mcp: Auto-wrap Click/Typer CLIs as MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [openai-agents](https://github.com/openai/openai-agents-python) - OpenAI's framework for building and managing AI agents.
   - [OpenChronicle](https://github.com/Einsia/OpenChronicle) - Open-source, local-first memory for any tool-capable LLM agent.
   - [promptise](https://github.com/promptise-com/foundry) - A framework for building end-to-end production-ready agentic systems, scalable & secure MCP's and autonomous agents.
+  - [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) - Auto-wrap any Click/Typer CLI as an MCP server for AI agents. Zero code changes.
   - [pydantic-ai](https://github.com/pydantic/pydantic-ai) - A Python agent framework for building generative AI applications with structured schemas.
   - [TradingAgents](https://github.com/TauricResearch/TradingAgents) - A multi-agents LLM financial trading framework.
 - Data Layer


### PR DESCRIPTION
## click-to-mcp

Adds [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) to the **AI and Agents > Orchestration** section.

**What it does:** Auto-wraps any Python Click or Typer CLI as an MCP (Model Context Protocol) server. Zero code changes needed — introspects commands at runtime and generates MCP tools from every command, argument, and option.

**Why it fits:** click-to-mcp bridges existing CLI tools with AI agent workflows. It enables any Click/Typer CLI to become accessible to AI coding agents (Claude Code, Cursor, etc.) via the MCP protocol, making it a natural fit alongside orchestration frameworks.

- Single project addition (as per guidelines)
- Added to the Orchestration subcategory alphabetically between promptise and pydantic-ai
- Concise description following existing format