### PR TITLE
Add bindu to AI and Agents > Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [ag2](https://github.com/ag2ai/ag2) - An open-source AgentOS for multi-agent orchestration and building agentic AI systems.
   - [autogen](https://github.com/microsoft/autogen) - A programming framework for building agentic AI applications.
   - [bernstein](https://github.com/sipyourdrink-ltd/bernstein) - A deterministic Python orchestrator for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40+ more) with parallel git worktrees and an HMAC-signed audit chain.
+  - [bindu](https://github.com/getbindu/Bindu) - A framework that wraps any agent handler with DID-based cryptographic identity, A2A JSON-RPC over HTTP, OAuth2 auth, x402 (USDC) payments, and a built-in operator inbox.
   - [bub](https://github.com/bubbuild/bub) - A lightweight, hook-first Python framework for channel-native agents that live alongside people.
   - [crewai](https://github.com/crewAIInc/crewAI) - A framework for orchestrating role-playing autonomous AI agents for collaborative task solving.
   - [dspy](https://github.com/stanfordnlp/dspy) - A framework for programming, not prompting, language models.


### PR DESCRIPTION
## Entry

```
- [bindu](https://github.com/getbindu/Bindu) - A framework that wraps any agent handler with DID-based cryptographic identity, A2A JSON-RPC over HTTP, OAuth2 auth, x402 (USDC) payments, and a built-in operator inbox.
```

## Justification

**Acceptance criterion: Rising Star.**

Bindu is a Python framework that gives autonomous AI agents the boring-plumbing layer they all reinvent — cryptographic identity (DIDs over Ed25519), the [A2A protocol](https://github.com/a2aproject/A2A) other agents already speak, OAuth2 via Ory Hydra, and pay-per-call billing using Coinbase's [x402](https://github.com/coinbase/x402) standard on EVM chains. You wrap a handler with ``bindufy()`` and the agent comes online as a self-contained HTTP service with its own identity.

It belongs in **AI and Agents > Orchestration** alongside ``crewai``, ``langchain``, ``pydantic-ai``, ``ag2``, and ``openai-agents`` — but unlike those, Bindu is framework-agnostic at the handler layer (Agno, LangChain, CrewAI, custom code all work) and adds the inter-agent transport + identity + payment layer they don't ship.

## Quality requirements

- [x] **Python-first**: 67% Python, 33% TypeScript (SDK + inbox UI). Core runtime is Python.
- [x] **Active**: last push today, 2026.20.7 release shipped 2026-05-17.
- [x] **Stable**: production releases since v0.1.0 (May 2025); on PyPI as ``bindu``.
- [x] **Documented**: full docs at https://docs.getbindu.com plus an inbox walkthrough.
- [x] **Unique**: only Python agent framework I know of that ships DID identity + A2A protocol + x402 payments in one piece; the existing orchestration entries don't cover identity or payment.
- [x] **Established**: repo created 2025-03, first release 2025-05.

## Rising Star evidence

- 6,200+ GitHub stars
- First release v0.1.0 in May 2025 — under 12 months ago
- 377 forks
- Active community on Discord, daily commits