### PR TITLE
Add configdrift to Configuration Files section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,6 +1088,7 @@ _Libraries for storing and parsing configuration options._
 - [hydra](https://github.com/facebookresearch/hydra) - Hydra is a framework for elegantly configuring complex applications.
 - [python-decouple](https://github.com/HBNetwork/python-decouple) - Strict separation of settings from code.
 - [python-dotenv](https://github.com/theskumar/python-dotenv) - Reads key-value pairs from a `.env` file and sets them as environment variables.
+- [configdrift](https://github.com/coding-dev-tools/configdrift) - Detect configuration drift across environments before it causes incidents.
 
 **Security**
 


### PR DESCRIPTION
Adds [configdrift](https://github.com/coding-dev-tools/configdrift) to the Configuration Files section.

**configdrift** detects configuration drift across environments before it causes incidents. It compares YAML, TOML, and .env files across directories and highlights differences — useful for teams managing multi-environment configs with Ansible, Terraform, or Kubernetes.

- Python CLI tool with MCP server support
- Compares config files across dev/staging/prod environments
- Outputs structured diff with severity levels
- CI-friendly exit codes for automated drift checks

Fits the Configuration Files section alongside python-dotenv and dynaconf.