### PR TITLE
Add deploydiff to DevOps Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,7 @@ _Software and libraries for DevOps._
 - Deployment
   - [chalice](https://github.com/aws/chalice) - A Python serverless microframework for AWS.
   - [fabric](https://github.com/fabric/fabric) - A simple, Pythonic tool for remote execution and deployment.
+  - [deploydiff](https://github.com/coding-dev-tools/deploydiff) - Preview infrastructure cost and configuration changes before deploying.
 - Monitoring and Processes
   - [psutil](https://github.com/giampaolo/psutil) - A cross-platform process and system utilities module.
   - [sentry-python](https://github.com/getsentry/sentry-python) - Sentry SDK for Python.


### PR DESCRIPTION
Adds [deploydiff](https://github.com/coding-dev-tools/deploydiff) to the DevOps Tools > Deployment section.

**deploydiff** previews infrastructure cost and configuration changes before deploying. It parses Terraform, CloudFormation, and Pulumi plan files to show diffs with cost estimation — like Infracost but as a standalone CLI with MCP server support.

- Python CLI tool with structured plan diff output
- Cost estimation for Terraform and CloudFormation plans
- CI-friendly: exit on cost threshold breaches
- MCP server for AI-assisted infrastructure review

Fits the Deployment sub-section alongside fabric and chalice.