### PR TITLE
Add datamorph-cli to Data Ingestion / ETL section

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ _Libraries for data extraction, transformation, and loading pipelines across mul
 
 - General
   - [dlt](https://github.com/dlt-hub/dlt) - A Python library for building data pipelines with automatic schema inference, incremental loading, and support for multiple sources and destinations.
+  - [datamorph-cli](https://github.com/coding-dev-tools/datamorph) - Convert between CSV, JSON, YAML, Parquet, Avro, and Protobuf data formats.
 - Financial Data
   - [akshare](https://github.com/akfamily/akshare) - A financial data interface library, built for human beings!
   - [edgartools](https://github.com/dgunning/edgartools) - Library for downloading structured data from SEC EDGAR filings and XBRL financial statements.


### PR DESCRIPTION
Adds [datamorph-cli](https://github.com/coding-dev-tools/datamorph) to the Data Ingestion / ETL > General section.

**datamorph-cli** converts between CSV, JSON, YAML, Parquet, Avro, and Protobuf data formats. It's a lightweight CLI tool for data pipeline engineers who need quick format conversions without writing scripts.

- Python CLI tool for multi-format data conversion
- Supports 6 formats: CSV, JSON, YAML, Parquet, Avro, Protobuf
- Schema inference and validation during conversion
- Pipe-friendly for ETL pipeline integration

Fits the General sub-section alongside dlt for data pipeline tooling.