### PR TITLE
Add api-contract-guardian to Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ _Libraries for testing codebases and generating test data. Also see [awesome-pyt
     - [awesome-pytest](https://github.com/augustogoulart/awesome-pytest)
   - [robotframework](https://github.com/robotframework/robotframework) - A generic test automation framework.
   - [scanapi](https://github.com/scanapi/scanapi) - Automated Testing and Documentation for your REST API.
+  - [api-contract-guardian](https://github.com/coding-dev-tools/api-contract-guardian) - Catch breaking OpenAPI/REST API changes in CI before they reach production.
   - [unittest](https://docs.python.org/3/library/unittest.html) - (Python standard library) Unit testing framework.
 - Test Runners
   - [nox](https://github.com/wntrblm/nox) - Flexible test automation for Python.


### PR DESCRIPTION
Adds [api-contract-guardian](https://github.com/coding-dev-tools/api-contract-guardian) to the Testing > Frameworks section.

**api-contract-guardian** catches breaking OpenAPI/REST API changes in CI before they reach production. It compares API schemas between branches and reports contract violations — a CI-first approach to API backwards compatibility.

- Python CLI tool for OpenAPI schema diffing
- Detects breaking changes: removed endpoints, changed types, new required fields
- CI-friendly: exit code 1 on contract violations
- MCP server for AI-assisted API review

Fits the Frameworks sub-section alongside scanapi and schemathesis for API testing tooling.