### PR TITLE
Add schemaforge-py to CLI Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ _Useful CLI-based tools for productivity._
 - Productivity Tools
   - [cookiecutter](https://github.com/cookiecutter/cookiecutter) - A command-line utility that creates projects from cookiecutters (project templates).
   - [copier](https://github.com/copier-org/copier) - A library and command-line utility for rendering projects templates.
+  - [schemaforge-py](https://github.com/coding-dev-tools/schemaforge) - Bidirectional ORM schema conversion across 11 formats (SQLAlchemy, Django, Prisma, etc.).
   - [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
   - [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
   - [tmuxp](https://github.com/tmux-python/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.


### PR DESCRIPTION
Adds [schemaforge-py](https://github.com/coding-dev-tools/schemaforge) to the CLI Tools > Productivity Tools section.

**schemaforge-py** provides bidirectional ORM schema conversion across 11 formats including SQLAlchemy, Django, Prisma, Pydantic, Marshmallow, and more. It lets developers translate schema definitions between frameworks without manual rewriting.

- Python CLI tool for schema migration between ORMs
- Supports 11 formats: SQLAlchemy, Django, Prisma, Pydantic, Marshmallow, OpenAPI, etc.
- Bidirectional conversion: any format to any format
- MCP server for AI-assisted schema translation

Fits the Productivity Tools sub-section alongside cookiecutter and copier for project scaffolding and tooling.