### PR TITLE
Add json2sql to Data Ingestion / ETL section

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ _Libraries for data extraction, transformation, and loading pipelines across mul
 
 - General
   - [dlt](https://github.com/dlt-hub/dlt) - A Python library for building data pipelines with automatic schema inference, incremental loading, and support for multiple sources and destinations.
+  - [json2sql](https://github.com/coding-dev-tools/json2sql) - Convert JSON data to SQL INSERT statements with automatic schema inference.
 - Financial Data
   - [akshare](https://github.com/akfamily/akshare) - A financial data interface library, built for human beings!
   - [edgartools](https://github.com/dgunning/edgartools) - Library for downloading structured data from SEC EDGAR filings and XBRL financial statements.


### PR DESCRIPTION
### Add json2sql to Data Ingestion / ETL

**json2sql** converts JSON data to SQL INSERT statements with automatic schema inference. Enables rapid data ingestion from JSON APIs and files into relational databases.

**Hidden Gem** submission:
- Repository: https://github.com/Coding-Dev-Tools/json2sql
- Python-first (>50% Python), actively maintained
- Solves common ETL pain point: getting JSON data into SQL databases
- One tool per PR as per contribution guidelines