### PR TITLE
docs: add RustChain to awesome-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ An opinionated guide to the best Python frameworks, libraries, tools, and resour
 
 **AI & ML**
 
-### AI and Agents
+### AI
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Activity blockchain that rewards vintage hardware.
+ and Agents
 
 _Libraries for building AI applications, LLM integrations, and autonomous agents._
 


### PR DESCRIPTION
Adds [RustChain](https://github.com/Scottcjn/Rustchain) to the Python awesome list.

Proof-of-Activity blockchain that rewards vintage hardware.

Closes rustchain-bounties#2862