### PR TITLE
Add envyzer to Configuration Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,6 +1086,7 @@ _Libraries for storing and parsing configuration options._
 
 - [configparser](https://docs.python.org/3/library/configparser.html) - (Python standard library) INI file parser.
 - [dynaconf](https://github.com/dynaconf/dynaconf) - Dynaconf is a configuration manager with plugins for Django, Flask and FastAPI.
+- [envyzer](https://github.com/shyh26/envyzer) - Validate and compare .env files across environments to catch missing or mismatched variables.
 - [hydra](https://github.com/facebookresearch/hydra) - Hydra is a framework for elegantly configuring complex applications.
 - [python-decouple](https://github.com/HBNetwork/python-decouple) - Strict separation of settings from code.
 - [python-dotenv](https://github.com/theskumar/python-dotenv) - Reads key-value pairs from a `.env` file and sets them as environment variables.


### PR DESCRIPTION
envyzer validates and compares .env files across environments to catch missing or mismatched variables before they break production.

- Multi-file comparison (2+ .env files at once)
- Three issue types: missing, extra, mismatch
- Rich terminal output with color-coded tables
- CI-friendly: non-zero exit on issues

GitHub: https://github.com/shyh26/envyzer

One-time 2, MIT licensed.