### PR TITLE
Add linkedin2md: convert LinkedIn data exports to Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ _Useful CLI-based tools for productivity._
   - [tmuxp](https://github.com/tmux-python/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.
   - [xonsh](https://github.com/xonsh/xonsh/) - A Python-powered shell. Full-featured and cross-platform.
   - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A command-line program to download videos from YouTube and other video sites, a fork of youtube-dl.
+  - [linkedin2md](https://github.com/juanmanueldaza/linkedin2md) - Convert LinkedIn data exports to Markdown for LLM analysis and PDF resume generation.
 - CLI Enhancements
   - [httpie](https://github.com/httpie/cli) - A command line HTTP client, a user-friendly cURL replacement.
   - [iredis](https://github.com/laixintao/iredis) - Redis CLI with autocompletion and syntax highlighting.


### PR DESCRIPTION
## linkedin2md — Hidden Gem submission

### Justification for inclusion (Hidden Gem criteria)

**linkedin2md** solves a unique niche problem that no other tool addresses: converting LinkedIn data exports into clean, structured Markdown for LLM analysis and PDF resume generation.

**Why it's a Hidden Gem:**

- **Unique niche**: No other Python tool converts LinkedIn's proprietary HTML/CSV export format into LLM-ready Markdown. It fills a gap between "data export" and "data usability" that's critical for the growing LLM/RAG ecosystem.
- **Zero dependencies**: True zero-dep CLI — `pip install linkedin2md` and it works. No heavy frameworks, no API keys, fully local and private.
- **Active and documented**: Created Jan 2026, actively maintained (latest release v0.3.1), with comprehensive docs, CI/CD, and external contributors already submitting PRs.
- **Real-world usage**: 4,500+ PyPI downloads, 14 GitHub stars, and growing — external contributors are engaging (PRs from ttttttjj and blinkerbit).
- **Part of a pipeline**: Complements [github2md](https://github.com/juanmanueldaza/github2md) and [gitlab2md](https://github.com/juanmanueldaza/gitlab2md) for a complete platform-data-to-Markdown pipeline.

**PyPI:** https://pypi.org/project/linkedin2md/
**GitHub:** https://github.com/juanmanueldaza/linkedin2md