### PR TITLE
Add FunASR to Speech section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [vllm](https://github.com/vllm-project/vllm) - A high-throughput and memory-efficient inference and serving engine for LLMs.
 - Speech
   - [openai-whisper](https://github.com/openai/whisper) - A general-purpose automatic speech recognition model trained on 680k hours of multilingual and multitask supervised data.
+  - [funasr](https://github.com/modelscope/FunASR) - Industrial-grade speech recognition toolkit with 170x realtime speed, 50+ languages, speaker diarization, and emotion detection.
   - [vibevoice](https://github.com/microsoft/VibeVoice) - A family of open-source voice AI models from Microsoft for text-to-speech and long-form speech recognition.
   - [voxcpm](https://github.com/OpenBMB/VoxCPM) - A tokenizer-free text-to-speech foundation model for multilingual speech generation and voice cloning.
 


### PR DESCRIPTION
Add [FunASR](https://github.com/modelscope/FunASR) to the Speech section.

**Why it belongs:**
- 16K+ GitHub stars (more than most items on this list)
- Industrial-grade ASR toolkit from Alibaba DAMO Academy
- 170x realtime on GPU (13x faster than Whisper)
- 50+ languages, speaker diarization, emotion detection
- Active maintenance (v1.3.3 released May 2026)
- MIT license
- Available on PyPI: `pip install funasr`