### PR TITLE
Add Prompter - terminal-based Ollama model comparison tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,7 @@ _Useful CLI-based tools for productivity._
   - [tmuxp](https://github.com/tmux-python/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.
   - [xonsh](https://github.com/xonsh/xonsh/) - A Python-powered shell. Full-featured and cross-platform.
   - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A command-line program to download videos from YouTube and other video sites, a fork of youtube-dl.
+  - [Prompter](https://github.com/whonixnetworks/prompter) - Terminal-based multi-model prompt comparison for Ollama. Compare LLM responses side-by-side, curses TUI, single-file, zero dependencies.
 - CLI Enhancements
   - [httpie](https://github.com/httpie/cli) - A command line HTTP client, a user-friendly cURL replacement.
   - [iredis](https://github.com/laixintao/iredis) - Redis CLI with autocompletion and syntax highlighting.


### PR DESCRIPTION
## Description

Add [Prompter](https://github.com/whonixnetworks/prompter) — a terminal-based multi-model prompt comparison tool for Ollama. Compare LLM responses side-by-side, curses TUI, single-file, zero dependencies.

Placed under CLI Tools > Productivity Tools, matching the format of existing entries.