### PR TITLE
Add json2sql to Data Ingestion / ETL section

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ _Libraries for data extraction, transformation, and loading pipelines across mul
 
 - General
   - [dlt](https://github.com/dlt-hub/dlt) - A Python library for building data pipelines with automatic schema inference, incremental loading, and support for multiple sources and destinations.
+  - [json2sql-cli](https://github.com/coding-dev-tools/json2sql) - Convert JSON files and APIs to SQL schemas, inserts, and queries with auto schema inference.
 - Financial Data
   - [akshare](https://github.com/akfamily/akshare) - A financial data interface library, built for human beings!
   - [edgartools](https://github.com/dgunning/edgartools) - Library for downloading structured data from SEC EDGAR filings and XBRL financial statements.


### PR DESCRIPTION
## Summary
- Add [json2sql](https://github.com/Coding-Dev-Tools/json2sql) to the Data Ingestion / ETL > General sub-section.

## About json2sql
json2sql is a CLI tool that converts JSON arrays and objects to SQL INSERT statements from the command line. It fits the ETL category as a data transformation tool — converting JSON data (a common API response format) into SQL statements ready for database ingestion.

- **GitHub**: https://github.com/Coding-Dev-Tools/json2sql
- **Stars**: 1
- **License**: MIT
- **Active**: Maintained and receiving updates

## Validation
- Ran `git diff --check` — no trailing whitespace or merge conflict markers.
- Entry follows existing format: `[Name](URL) - Description.`
- Placed in the General sub-section of Data Ingestion / ETL as a data transformation tool.
- Description matches the repo's tagline and is consistent with other entries.