### PR TITLE
Add Jumpstarter to Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,6 +1120,7 @@ _Libraries for application-layer web security._
 _Libraries for programming with hardware._
 
 - [bleak](https://github.com/hbldh/bleak) - A cross platform Bluetooth Low Energy Client for Python using asyncio.
+- [jumpstarter](https://github.com/jumpstarter-dev/jumpstarter) - A hardware-in-the-loop testing framework with a Python client library for automated testing on real and virtual hardware.
 - [pynput](https://github.com/moses-palmer/pynput) - A library to control and monitor input devices.
 
 ### Microsoft Windows


### PR DESCRIPTION
Add Jumpstarter, an open source hardware-in-the-loop testing framework with a Python client library for automated testing on real and virtual hardware.

https://github.com/jumpstarter-dev/jumpstarter