### PR TITLE
docs: add scikit-lego to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ _Libraries for Machine Learning. Also see [awesome-machine-learning](https://git
 - [mindsdb](https://github.com/mindsdb/mindsdb) - MindsDB is an open source AI layer for existing databases that allows you to effortlessly develop, train and deploy state-of-the-art machine learning models using standard queries.
 - [pgmpy](https://github.com/pgmpy/pgmpy) - A Python library for probabilistic graphical models and Bayesian networks.
 - [scikit-learn](https://github.com/scikit-learn/scikit-learn) - The most popular Python library for Machine Learning with extensive documentation and community support.
+- * [scikit-lego](https://github.com/koaning/scikit-lego) - A collection of lego bricks for scikit-learn pipelines.
 - [spark.ml](https://github.com/apache/spark) - [Apache Spark](https://spark.apache.org/)'s scalable [Machine Learning library](https://spark.apache.org/docs/latest/ml-guide.html) for distributed computing.
 - [TabGAN](https://github.com/Diyago/Tabular-data-generation) - Synthetic tabular data generation using GANs, Diffusion Models, and LLMs.
 - [timesfm](https://github.com/google-research/timesfm) - A pretrained foundation model from Google Research for time-series forecasting.


### PR DESCRIPTION
Hello maintainers.

I noticed that the "Machine Learning" section is currently missing `scikit-lego`, which is a highly utilized and active library within the data science community for building clean, custom scikit-learn pipelines without boilerplate code.

I would love to contribute by proposing its addition to this amazing list. I have carefully read the CONTRIBUTING.md guidelines and ensured that:
* The repository for the library is active and of high quality.
* The entry has been added in strict alphabetical order.
* The formatting matches the repository standards exactly.

I'm open to any feedback or adjustments you might consider necessary. Thank you for your time and for maintaining this resource!