### PR TITLE
Add chdb to Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ _Libraries for connecting and operating databases._
 
 _Databases implemented in Python._
 
+- [chdb](https://github.com/chdb-io/chdb) - In-process OLAP SQL engine with the full ClickHouse dialect, zero-copy pandas/Arrow interop, and federation to remote ClickHouse clusters via `remoteSecure()`.
 - [chromadb](https://github.com/chroma-core/chroma) - An open-source embedding database for building AI applications with embeddings and semantic search.
 - [duckdb](https://github.com/duckdb/duckdb) - An in-process SQL OLAP database management system; optimized for analytics and fast queries, similar to SQLite but for analytical workloads.
 - [pickledb](https://github.com/patx/pickledb) - A simple and lightweight key-value store for Python.


### PR DESCRIPTION
Adds chdb to the Database section.

chdb is an in-process OLAP SQL engine that embeds the full ClickHouse
query engine in Python. It runs the complete ClickHouse SQL dialect
(1000+ functions), queries Parquet/CSV/JSON files in place, references
pandas DataFrames directly in SQL with zero-copy, and federates to remote
ClickHouse clusters via \`remoteSecure()\`.

- PyPI: https://pypi.org/project/chdb/ (v4.1.8, 2026-05-22)
- Repo: https://github.com/chdb-io/chdb
- License: Apache-2.0
- Stars: 2,690
- Active: last commit 2026-05-27
- First release: 2023; consistent release cadence over 3+ years

Acceptance criteria: Hidden Gem — chdb solves the niche of running the
ClickHouse SQL surface in-process in Python. Demonstrated real-world
usage includes Hex's first-class integration and inclusion in ClickBench.
The repository is 3+ years old with a multi-language binding ecosystem
(Python / Bun / Go / Rust / Ruby / Zig / Java / .NET).