### PR TITLE
Add net-benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,6 +830,7 @@ _Useful CLI-based tools for productivity._
   - [iredis](https://github.com/laixintao/iredis) - Redis CLI with autocompletion and syntax highlighting.
   - [litecli](https://github.com/dbcli/litecli) - SQLite CLI with autocompletion and syntax highlighting.
   - [mycli](https://github.com/dbcli/mycli) - MySQL CLI with autocompletion and syntax highlighting.
+  - [net-benchmark](https://github.com/net-benchmark/net-benchmark) — DNS/HTTP/SSL benchmarking CLI.
   - [pgcli](https://github.com/dbcli/pgcli) - PostgreSQL CLI with autocompletion and syntax highlighting.
 
 ### GUI Development


### PR DESCRIPTION
## Project

[net-benchmark](https://github.com/net-benchmark/net-benchmark)

## Checklist

- [x] One project per PR  
- [x] PR title format: `Add net-benchmark`  
- [x] Entry format: `- [net-benchmark](https://github.com/net-benchmark/net-benchmark) — DNS/HTTP/SSL benchmarking CLI.`  
- [x] Description is concise and short  

## Why This Project Is Awesome

- [x] **Hidden Gem** — Exceptional quality, solves niche problems elegantly

Combines DNS, HTTP and SSL benchmarking under a single CLI with consistent command patterns and export formats. Grew to 14,000+ installs across 100+ countries organically with zero marketing. No comparable tool offers DoH, DoT, DNSSEC validation alongside full HTTP timing breakdown (DNS→TCP→TLS→TTFB→TTLB) and security header auditing from one binary.

## How It Differs

Existing tools like `httpie` handle HTTP only, and `dig`/`dnsx` handle DNS only. net-benchmark is the only Python CLI combining DNS (including DoH, DoT, DNSSEC) and HTTP benchmarking under one interface with unified commands and export formats.
