### PR TITLE
Add hummbl-governance to AI and Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [crewai](https://github.com/crewAIInc/crewAI) - A framework for orchestrating role-playing autonomous AI agents for collaborative task solving.
   - [dspy](https://github.com/stanfordnlp/dspy) - A framework for programming, not prompting, language models.
   - [hermes-agent](https://github.com/nousresearch/hermes-agent) - An adaptive AI agent framework that grows with you.
+  - [hummbl-governance](https://github.com/hummbl-dev/hummbl-governance) - 25 stdlib-only Python primitives for multi-agent AI governance: kill switch, circuit breaker, cost governor, delegation tokens, and audit logging.
   - [langchain](https://github.com/langchain-ai/langchain) - Building applications with LLMs through composability.
   - [openai-agents](https://github.com/openai/openai-agents-python) - OpenAI's framework for building and managing AI agents.
   - [OpenChronicle](https://github.com/Einsia/OpenChronicle) - Open-source, local-first memory for any tool-capable LLM agent.


### PR DESCRIPTION
25 stdlib-only Python primitives for multi-agent AI governance: kill switch, circuit breaker, cost governor, delegation tokens, audit logging, health probes, and compliance mapping.

- Zero third-party dependencies (stdlib only)
- 1,026 tests across 25 primitives
- Python 3.11–3.14
- v1.0.0 with API stability guarantee
- Includes 7 MCP servers exposing primitives as JSON-RPC tools

Also includes a runnable demo repo: https://github.com/hummbl-dev/founder-mode-showcase