### PR TITLE
Add nuwa-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
 - Agent Skills
   - [django-ai-plugins](https://github.com/vintasoftware/django-ai-plugins) - Django backend agent skills for Django, DRF, Celery, and Django-specific code review.
   - [graphify](https://github.com/safishamsi/graphify) - Turn any folder of code, SQL schemas, R scripts, shell scripts, docs, papers, images, or videos into a queryable knowledge graph.
+  - [nuwa-skill](https://github.com/alchaincyf/nuwa-skill/blob/main/README_EN.md) - Nuwa distills the thinking of anyone — let Musk, Naval, Munger, and Feynman work for you.
   - [sentry-skills](https://github.com/getsentry/skills) - Python-focused engineering skills for code review, debugging, and backend workflows.
   - [trailofbits-skills](https://github.com/trailofbits/skills) - Python-friendly security skills for auditing, testing, and safer backend development. Also [skills-curated](https://github.com/trailofbits/skills-curated).
 - Orchestration


### PR DESCRIPTION
## Project

[nuwa-skill](https://github.com/alchaincyf/nuwa-skill)

## Checklist

- [X] One project per PR
- [X] PR title format: `Add project-name`
- [X] Entry format: `- [project-name](url) - Description ending with period.`
- [X] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [X] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [ ] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

## How It Differs

It'a s skill to distill any one, with lots of people already distilled. 

The project default language is Chinese, the entry url points to the English readme. 
