### PR TITLE
Add python-automation-toolkit to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,7 @@ _Useful CLI-based tools for productivity._
   - [tmuxp](https://github.com/tmux-python/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.
   - [xonsh](https://github.com/xonsh/xonsh/) - A Python-powered shell. Full-featured and cross-platform.
   - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A command-line program to download videos from YouTube and other video sites, a fork of youtube-dl.
+  - [python-automation-toolkit](https://github.com/alexl668/python-automation-toolkit) - 50+ production-ready Python scripts for web scraping, data processing, email automation, API monitoring, and file management.
 - CLI Enhancements
   - [httpie](https://github.com/httpie/cli) - A command line HTTP client, a user-friendly cURL replacement.
   - [iredis](https://github.com/laixintao/iredis) - Redis CLI with autocompletion and syntax highlighting.


### PR DESCRIPTION
## What

Added [python-automation-toolkit](https://github.com/alexl668/python-automation-toolkit) to the **CLI Tools > Productivity Tools** section.

### Why it belongs here:
- 50+ production-ready Python automation scripts
- CLI-first design with Click + Rich terminal UI
- Covers web scraping, data processing, email automation, API monitoring, file management, and finance tracking
- Full source code, MIT License
- 14 GitHub stars and growing

### Categories covered:
- 🕷️ Web Scraping (price monitors, SEO extractors, job aggregators)
- 📊 Data Processing (CSV/JSON/log transformers)
- 📧 Email Automation (bulk senders, inbox analyzers)
- 🌐 API Services (health monitors, webhook receivers)
- 📁 File System (duplicate finders, backup systems)
- 💰 Finance & Crypto (expense trackers, invoice generators)