### PR TITLE
Add pytest-mrt under Testing > Database Migration Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,8 @@ _Libraries for testing codebases and generating test data. Also see [awesome-pyt
 - Fake Data
   - [faker](https://github.com/joke2k/faker) - A Python package that generates fake data.
   - [mimesis](https://github.com/lk-geimfari/mimesis) - is a Python library that help you generate fake data.
+- Database Migration Testing
+  - [pytest-mrt](https://github.com/croc100/pytest-mrt) - A pytest plugin for verifying that Alembic and Django database migrations are safely reversible.
 
 ### Debugging Tools
 


### PR DESCRIPTION
pytest-mrt is a pytest plugin for testing Alembic and Django migration rollback safety. It runs the actual up/down cycle against a real database and checks that data survives, and also does static analysis on migration files to catch things like missing `downgrade()`, `DROP COLUMN` in upgrade, etc.

Didn't see an existing section for migration testing tools so proposed a new subsection under Testing.

- PyPI: https://pypi.org/project/pytest-mrt/
- Docs: https://croc100.github.io/pytest-mrt
- MIT, actively maintained