### PR TITLE
fix: correct authlib description in Authentication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ _Tools for managing, compressing and minifying website assets._
 _Libraries for implementing authentication schemes._
 
 - OAuth
-  - [authlib](https://github.com/authlib/authlib) - JavaScript Object Signing and Encryption draft implementation.
+  - [authlib](https://github.com/authlib/authlib) - A comprehensive library for building OAuth 1.0, OAuth 2.0, and OpenID Connect clients and servers.
   - [django-allauth](https://github.com/pennersr/django-allauth) - Authentication app for Django that "just works."
   - [django-oauth-toolkit](https://github.com/django-oauth/django-oauth-toolkit) - OAuth 2 goodies for Django.
   - [oauthlib](https://github.com/oauthlib/oauthlib) - A generic and thorough implementation of the OAuth request-signing logic.

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ _Tools for managing, compressing and minifying website assets._
 _Libraries for implementing authentication schemes._
 
 - OAuth
-  - [authlib](https://github.com/authlib/authlib) - A comprehensive library for building OAuth 1.0, OAuth 2.0, and OpenID Connect clients and servers.
+  - [authlib](https://github.com/authlib/authlib) - A comprehensive library for building OAuth, OpenID Connect, and JWT/JWS/JWE/JWK/JWA.
   - [django-allauth](https://github.com/pennersr/django-allauth) - Authentication app for Django that "just works."
   - [django-oauth-toolkit](https://github.com/django-oauth/django-oauth-toolkit) - OAuth 2 goodies for Django.
   - [oauthlib](https://github.com/oauthlib/oauthlib) - A generic and thorough implementation of the OAuth request-signing logic.


### PR DESCRIPTION
## Summary

Fixes the description of `authlib` in the **Authentication > OAuth** section.

### Current (incorrect):
> JavaScript Object Signing and Encryption draft implementation.

### Proposed (correct):
> A comprehensive library for building OAuth 1.0, OAuth 2.0, and OpenID Connect clients and servers.

### Why this change?
The current description is inaccurate and appears to be a copy-paste error. Authlib is a Python library for OAuth and OpenID Connect — it is not a "JavaScript" library. The JOSE (JSON Object Signing and Encryption) functionality is just one feature of Authlib, not its primary purpose.

The proposed description accurately reflects Authlib's scope as documented on its [official README](https://github.com/authlib/authlib#readme): _"The ultimate Python library in building OAuth and OpenID Connect servers and clients."_

### Checklist
- [x] Description is accurate and concise
- [x] Entry follows the correct format
- [x] No duplicate entries