### PR TITLE
fix: update outdated version references in descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ _Libraries for building RESTful and GraphQL APIs._
   - [connexion](https://github.com/spec-first/connexion) - A spec-first framework that automatically handles requests based on your OpenAPI specification.
   - [falcon](https://github.com/falconry/falcon) - A high-performance framework for building cloud APIs and web app backends.
   - [fastapi](https://github.com/fastapi/fastapi) - A modern, fast, web framework for building APIs with standard Python type hints.
-  - [sanic](https://github.com/sanic-org/sanic) - A Python 3.6+ web server and web framework that's written to go fast.
+  - [sanic](https://github.com/sanic-org/sanic) - A Python web server and web framework that's written to go fast.
   - [strawberry](https://github.com/strawberry-graphql/strawberry) - A GraphQL library that leverages Python type annotations for schema definition.
   - [webargs](https://github.com/marshmallow-code/webargs) - A friendly library for parsing HTTP request arguments with built-in support for popular web frameworks.
 
@@ -326,7 +326,7 @@ _Libraries for implementing authentication schemes._
 - JWT
   - [pyjwt](https://github.com/jpadilla/pyjwt) - JSON Web Token implementation in Python.
 - Permissions
-  - [django-guardian](https://github.com/django-guardian/django-guardian) - Implementation of per object permissions for Django 1.2+
+  - [django-guardian](https://github.com/django-guardian/django-guardian) - Implementation of per-object permissions for Django.
   - [django-rules](https://github.com/dfunckt/django-rules) - A tiny but powerful app providing object-level permissions to Django, without requiring a database.
 
 ### Admin Panels


### PR DESCRIPTION
## Summary

Removes outdated version constraints from two library descriptions.

### Changes

1. **sanic** (Web APIs > Framework Agnostic)
   - Before: `A Python 3.6+ web server and web framework that's written to go fast.`
   - After: `A Python web server and web framework that's written to go fast.`
   - Reason: Sanic now requires Python >=3.10 ([PyPI](https://pypi.org/project/sanic/)). The "3.6+" constraint is outdated and misleading.

2. **django-guardian** (Authentication > Permissions)
   - Before: `Implementation of per object permissions for Django 1.2+`
   - After: `Implementation of per-object permissions for Django.`
   - Reason: The "Django 1.2+" reference is severely outdated (Django 1.2 was released in 2011). Current version requires Python >=3.10 ([PyPI](https://pypi.org/project/django-guardian/)). Also fixed minor grammar: "per object" → "per-object".

### Why remove version numbers instead of updating them?

Hardcoding version requirements in descriptions creates ongoing maintenance burden. Since version info is readily available on PyPI, removing them keeps the descriptions clean and timeless.

### Checklist
- [x] Descriptions are accurate and concise
- [x] Entries follow the correct format
- [x] No duplicate entries