### PR TITLE
fix: update chardet description to remove outdated Python 2 reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,7 +869,7 @@ _Libraries for parsing and manipulating plain texts._
 
 - General
   - [babel](https://github.com/python-babel/babel) - An internationalization library for Python.
-  - [chardet](https://github.com/chardet/chardet) - Python 2/3 compatible character encoding detector.
+  - [chardet](https://github.com/chardet/chardet) - Python character encoding detector.
   - [difflib](https://docs.python.org/3/library/difflib.html) - (Python standard library) Helpers for computing deltas.
   - [ftfy](https://github.com/rspeer/python-ftfy) - Makes Unicode text less broken and more consistent automagically.
   - [pangu.py](https://github.com/vinta/pangu.py) - Paranoid text spacing.


### PR DESCRIPTION
## Summary

Updates the description of `chardet` in the **Text Processing > General** section.

### Current (outdated):
> Python 2/3 compatible character encoding detector.

### Proposed (updated):
> Python character encoding detector.

### Why this change?
Python 2 reached end-of-life on January 1, 2020. The "Python 2/3 compatible" qualifier is no longer relevant and may mislead users into thinking Python 2 is still actively supported. The updated description matches the [official repository description](https://github.com/chardet/chardet).

### Checklist
- [x] Description is accurate and concise
- [x] Entry follows the correct format
- [x] No duplicate entries