### PR TITLE
feat: add TWZRD Agent Intel — Solana x402 MCP server for agent trust scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [nuwa-skill](https://github.com/alchaincyf/nuwa-skill/blob/main/README_EN.md) - Nuwa distills the thinking of anyone — let Musk, Naval, Munger, and Feynman work for you.
   - [sentry-skills](https://github.com/getsentry/skills) - Python-focused engineering skills for code review, debugging, and backend workflows.
   - [trailofbits-skills](https://github.com/trailofbits/skills) - Python-friendly security skills for auditing, testing, and safer backend development.
+- MCP Servers
+  - [twzrd-agent-intel](https://intel.twzrd.xyz) - Solana-native x402 MCP for agent trust scoring. 4 free preflight tools score any Solana wallet (on-chain activity, transaction patterns, network age, recurring behavior); paid tools return signed trust tokens via HTTP 402 + USDC (<1s settlement). Install: `pip install twzrd-agent-intel`.
 - Orchestration
   - [ag2](https://github.com/ag2ai/ag2) - An open-source AgentOS for multi-agent orchestration and building agentic AI systems.
   - [autogen](https://github.com/microsoft/autogen) - A programming framework for building agentic AI applications.


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **AI and Agents → MCP Servers** subsection (new subsection, alphabetically placed between Agent Skills and Orchestration).

**TWZRD Agent Intel** is a Python-installable MCP server for Solana agent trust scoring:

- **PyPI**: `pip install twzrd-agent-intel`
- **MCP endpoint**: `https://intel.twzrd.xyz/mcp`
- **4 free preflight tools** score any Solana wallet: on-chain activity, transaction patterns, network age, recurring behavior
- **Paid tools** return signed `twzrd.receipt.v5` trust tokens via HTTP 402 + USDC on Solana (<1s settlement)
- Designed for AI agents that need to verify counterparty trust before executing on-chain transactions

## Why it fits here

- It is a pip-installable Python package on [PyPI](https://pypi.org/project/twzrd-agent-intel/)
- It implements the Model Context Protocol (MCP) — the new standard for passing data/context to AI models referenced in this list
- It targets the autonomous agent use case specifically (agent-to-agent trust verification)

## Install

```bash
pip install twzrd-agent-intel
# or
claude mcp add twzrd-agent-intel --transport http https://intel.twzrd.xyz/mcp
```