### PR TITLE
Add outlines to AI and Agents (Data Layer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [instructor](https://github.com/567-labs/instructor) - A library for extracting structured data from LLMs, powered by Pydantic.
   - [llama-index](https://github.com/run-llama/llama_index) - A data framework for your LLM application.
   - [mem0](https://github.com/mem0ai/mem0) - An intelligent memory layer for AI agents enabling personalized interactions.
+  - [outlines](https://github.com/dottxt-ai/outlines) - Structured text generation for LLMs with JSON schema, regex, and grammar-constrained decoding.
 - Pre-trained Models and Inference
   - [diffusers](https://github.com/huggingface/diffusers) - A library that provides pre-trained diffusion models for generating and editing images, audio, and video.
   - [mlx-lm](https://github.com/ml-explore/mlx-lm) - Run and fine-tune large language models on Apple Silicon with MLX.


### PR DESCRIPTION
Adds [`outlines`](https://github.com/dottxt-ai/outlines), a library for constrained decoding of LLM outputs, under **AI and Agents → Data Layer**.

**Why it qualifies (all quality requirements met):**
- **Python-first:** 99.7% Python
- **Active:** commits within the last weeks
- **Stable:** production-ready, widely used across the structured-generation ecosystem
- **Documented:** README with multiple real-world examples (classification, extraction, parsing, templating)
- **Established:** repository ~2 years old with consistent activity

**Acceptance criteria — Industry Standard for its niche:**
13.9k+ stars and the de-facto tool for guaranteed-valid structured LLM output.

**Uniqueness (not a duplicate of `instructor`):**
`instructor` validates/parses output *after* generation via Pydantic and retries on failure. `outlines` enforces validity *during* token generation through JSON-schema / regex / context-free-grammar constrained decoding, so invalid output is structurally impossible rather than caught afterward. No constrained-decoding library currently exists in this list.