### PR TITLE
Add langgraph to AI and Agents (Orchestration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [dspy](https://github.com/stanfordnlp/dspy) - A framework for programming, not prompting, language models.
   - [hermes-agent](https://github.com/nousresearch/hermes-agent) - An adaptive AI agent framework that grows with you.
   - [langchain](https://github.com/langchain-ai/langchain) - Building applications with LLMs through composability.
+  - [langgraph](https://github.com/langchain-ai/langgraph) - Low-level orchestration framework for building stateful, long-running LLM agents.
   - [openai-agents](https://github.com/openai/openai-agents-python) - OpenAI's framework for building and managing AI agents.
   - [OpenChronicle](https://github.com/Einsia/OpenChronicle) - Open-source, local-first memory for any tool-capable LLM agent.
   - [promptise](https://github.com/promptise-com/foundry) - A framework for building end-to-end production-ready agentic systems, scalable & secure MCP's and autonomous agents.


### PR DESCRIPTION
Adds [`langgraph`](https://github.com/langchain-ai/langgraph) under **AI and Agents → Orchestration**.

**Why it qualifies (all quality requirements met):**
- **Python-first:** 99.6% Python
- **Active:** commits within the last days
- **Stable:** production-ready, 0.x releases used widely in production agent stacks
- **Documented:** thorough docs with quickstarts and examples
- **Established:** 34k+ stars

**Acceptance criteria — Industry Standard for its niche:**
The de-facto framework for graph-based, stateful agent orchestration (durable execution, human-in-the-loop, persistent memory), with very broad adoption.

**Uniqueness (not a duplicate of `langchain`):**
`langchain` is a composability layer for chaining LLM calls and integrations. `langgraph` is a separate, lower-level library that models an agent as a stateful graph with explicit nodes/edges, checkpointing/durable execution, and human-in-the-loop interrupts — used to build long-running agents that `langchain` itself does not provide. It is published as its own PyPI package (`pip install langgraph`).