### PR TITLE
Add NuriStat to Data Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ _Libraries for data analysis._
 - [desbordante](https://github.com/desbordante/desbordante-core/) - An open source data profiler for complex pattern discovery.
 - [ibis](https://github.com/ibis-project/ibis) - A portable Python dataframe library with a single API for 20+ backends.
 - [modin](https://github.com/modin-project/modin) - A drop-in pandas replacement that scales workflows by changing a single line of code.
+- [NuriStat](https://github.com/baramgay/stat) - A free, open-source SPSS replacement with 27+ analysis modules (ANOVA, regression, survival analysis, ROC), variable metadata, and SPSS file import/export.
 - [pandas](https://github.com/pandas-dev/pandas) - A library providing high-performance, easy-to-use data structures and data analysis tools.
 - [pathway](https://github.com/pathwaycom/pathway) - Real-time data processing framework for Python with reactive dataflows.
 - [polars](https://github.com/pola-rs/polars) - A fast DataFrame library implemented in Rust with a Python API.


### PR DESCRIPTION
## Description

Adding [NuriStat](https://github.com/baramgay/stat) to the Data Analysis section.

**NuriStat** is a free, open-source SPSS replacement built with Python and PySide6. It provides a familiar menu-driven GUI for researchers and clinicians who need statistical analysis without a commercial license.

## Why it belongs here

- Pure Python (PySide6 + pandas + scipy + statsmodels)
- 27+ analysis modules: ANOVA, regression, survival analysis, ROC, factor analysis, reliability (Cronbach α), and more
- SPSS file (.sav) import/export via pyreadstat
- Variable metadata (labels, value labels, missing value codes) — like SPSS, not pandas
- MIT licensed, cross-platform
- Active development, v3.6.1 released 2026-06-11

## Checklist

- [x] The project has a short description
- [x] The project is on GitHub (public)
- [x] The project has a README
- [x] The project has an OSI-approved open-source license (MIT)
- [x] Alphabetical order maintained within section