### PR TITLE
Add Celerp - self-hosted ERP

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ _Libraries for administrative interfaces._
 - [flower](https://github.com/mher/flower) - Real-time monitor and web admin for Celery.
 - [func-to-web](https://github.com/offerrall/FuncToWeb) - Instantly create web UIs from Python functions using type hints. Zero frontend code required.
 - [jet-bridge](https://github.com/jet-admin/jet-bridge) - Admin panel framework for any application with nice UI (ex Jet Django).
+- [celerp](https://github.com/celerp/celerp) - Self-hosted ERP with inventory, invoicing, manufacturing, and accounting. Web-based admin interface with click-to-edit data entry.
 
 ### CMS
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ _Libraries for administrative interfaces._
 - [flower](https://github.com/mher/flower) - Real-time monitor and web admin for Celery.
 - [func-to-web](https://github.com/offerrall/FuncToWeb) - Instantly create web UIs from Python functions using type hints. Zero frontend code required.
 - [jet-bridge](https://github.com/jet-admin/jet-bridge) - Admin panel framework for any application with nice UI (ex Jet Django).
-- [celerp](https://github.com/celerp/celerp) - Self-hosted ERP with inventory, invoicing, manufacturing, and accounting. Web-based admin interface with click-to-edit data entry.
+- [celerp](https://github.com/celerp/celerp) - Self-hosted ERP with inventory, invoicing, manufacturing, and accounting. Web-based admin interface with click-to-edit data entry. BSL-1.1
 
 ### CMS
 


### PR DESCRIPTION
Adds [Celerp](https://celerp.com) to the Admin Panels section.

Celerp is a pip-installable self-hosted ERP built on FastAPI. Key features:
- Web-based admin interface with click-to-edit data entry
- Inventory, invoicing, manufacturing, accounting
- REST API for programmatic access
- 18 industry presets, AI operator
- 3,100+ tests

```pip install celerp && celerp init```

[Source Code](https://github.com/celerp/celerp)