### PR TITLE
Add streamxl — Rust-powered streaming XLSX reader for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,6 +915,7 @@ _Libraries for parsing and manipulating specific text formats._
 - MS Office
   - [docxtpl](https://github.com/elapouya/python-docx-template) - Editing a docx document by jinja2 template
   - [openpyxl](https://openpyxl.readthedocs.io/en/stable/) - A library for reading and writing Excel 2010 xlsx/xlsm/xltx/xltm files.
+  - [streamxl](https://github.com/Mullassery/StreamXL) - High-performance streaming XLSX reader powered by a Rust engine (PyO3). Reads large Excel files row-by-row without loading into memory; 4-5x faster than openpyxl.
   - [pyexcel](https://github.com/pyexcel/pyexcel) - Providing one API for reading, manipulating and writing csv, ods, xls, xlsx and xlsm files.
   - [python-docx](https://github.com/python-openxml/python-docx) - Reads, queries and modifies Microsoft Word 2007/2008 docx files.
   - [python-pptx](https://github.com/scanny/python-pptx) - Python library for creating and updating PowerPoint (.pptx) files.


### PR DESCRIPTION
## streamxl

**https://github.com/Mullassery/StreamXL**

A Python library that reads `.xlsx` files row-by-row using a Rust engine (PyO3 + quick-xml), without loading the entire file into memory.

**Why it belongs in the MS Office section:**
- Direct alternative to openpyxl for *reading* large Excel files
- 4–5× faster than openpyxl, uses ~13× less memory at 250k rows
- Streams row-by-row — API is a single iterator: `for row in streamxl.read("file.xlsx")`
- Ships as a pip/uv wheel: `pip install streamxl`

**Author:** Georgi Mullassery  
**License:** MIT  
**PyPI:** https://pypi.org/project/streamxl/

Added alphabetically under the **MS Office** subsection of **Specific Formats Processing**.