### PR TITLE
Add scala-score to Data Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ _Libraries for data analysis._
 - [pandas](https://github.com/pandas-dev/pandas) - A library providing high-performance, easy-to-use data structures and data analysis tools.
 - [pathway](https://github.com/pathwaycom/pathway) - Real-time data processing framework for Python with reactive dataflows.
 - [polars](https://github.com/pola-rs/polars) - A fast DataFrame library implemented in Rust with a Python API.
+- [scala-score](https://github.com/Alessandro114/scala-score-python) - A Python SDK for searching and filtering 250M+ company records across 40+ countries.
 
 ### Data Ingestion / ETL
 


### PR DESCRIPTION
## Description

Add [scala-score](https://github.com/Alessandro114/scala-score-python) to the **Data Analysis** section.

**scala-score** is a Python SDK for searching and filtering 250M+ company records across 40+ countries via the S.C.A.L.A. Score API. It provides structured access to company firmographics — revenue, employees, credit scores, and legal status — making it a valuable tool for analysts and data scientists working with business intelligence data.

- **PyPI**: https://pypi.org/project/scala-score/
- **Install**: `pip install scala-score`
- **GitHub**: https://github.com/Alessandro114/scala-score-python

## Justification (Hidden Gem)

- **Unique value**: No other Python library provides a single `pip install` to search 250M+ company records across 40+ countries. Existing alternatives (OpenCorporates, Crunchbase) lack comparable Python SDKs or have significantly smaller datasets.
- **Production-ready**: Clean API with typed responses, pagination support, and error handling.
- **Documented**: Full README with usage examples, API reference, and real-world use cases.
- **Active maintenance**: Under active development with the S.C.A.L.A. Score BI platform.
- **Real-world usage**: Powers the data enrichment pipeline at S.C.A.L.A. AI OS, an enterprise AI operating system serving multiple industries.

## Category

**Data & Science > Data Analysis** — the SDK is used to query, filter, and analyze company records at scale, fitting alongside tools like pandas, polars, and datasette that help analysts work with large datasets.

## Checklist

- [x] Python-first (100% Python)
- [x] Production-ready
- [x] Documented with examples
- [x] Unique value proposition
- [x] Follows entry format guidelines
- [x] Alphabetical order maintained