### PR TITLE
Add enrich-companies to Data Ingestion / ETL

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ _Libraries for data extraction, transformation, and loading pipelines across mul
 
 - General
   - [dlt](https://github.com/dlt-hub/dlt) - A Python library for building data pipelines with automatic schema inference, incremental loading, and support for multiple sources and destinations.
+  - [enrich-companies](https://github.com/Alessandro114/enrich-companies-python) - A CLI tool to enrich CSV files with company data (revenue, employees, credit score) from 250M+ business records.
 - Financial Data
   - [akshare](https://github.com/akfamily/akshare) - A financial data interface library, built for human beings!
   - [edgartools](https://github.com/dgunning/edgartools) - Library for downloading structured data from SEC EDGAR filings and XBRL financial statements.


### PR DESCRIPTION
## Description

Add [enrich-companies](https://github.com/Alessandro114/enrich-companies-python) to the **Data Ingestion / ETL > General** section.

**enrich-companies** is a CLI tool that enriches CSV files with company data — revenue, employees, credit score, legal status — by matching against 250M+ business records across 40+ countries. It takes a CSV with company names/IDs as input and outputs an enriched CSV with additional firmographic columns.

- **PyPI**: https://pypi.org/project/enrich-companies/
- **Install**: `pip install enrich-companies`
- **GitHub**: https://github.com/Alessandro114/enrich-companies-python

## Justification (Hidden Gem)

- **Unique value**: No other `pip install`-able CLI tool provides batch CSV enrichment against a 250M+ company database. Existing alternatives (Clearbit, ZoomInfo) are expensive SaaS products without open-source CLIs.
- **Practical**: Solves a real pain point for data analysts and sales teams who need to enrich company lists without manual lookups or expensive API contracts.
- **Production-ready**: Simple CLI interface (`enrich-companies input.csv -o output.csv`) with progress bars, error handling, and configurable column mapping.
- **Documented**: Full README with installation, usage examples, and output format documentation.
- **Active maintenance**: Under active development as part of the S.C.A.L.A. Score BI platform.

## Category

**Data & Science > Data Ingestion / ETL > General** — the tool ingests CSV data, enriches it with external company records, and outputs transformed CSVs, which is a classic ETL workflow.

## Checklist

- [x] Python-first (100% Python)
- [x] Production-ready
- [x] Documented with examples
- [x] Unique value proposition
- [x] Follows entry format guidelines
- [x] Alphabetical order maintained