### PR TITLE
Add runlet to AI and Agents / Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [openai-agents](https://github.com/openai/openai-agents-python) - OpenAI's framework for building and managing AI agents.
   - [OpenChronicle](https://github.com/Einsia/OpenChronicle) - Open-source, local-first memory for any tool-capable LLM agent.
   - [promptise](https://github.com/promptise-com/foundry) - A framework for building end-to-end production-ready agentic systems, scalable & secure MCP's and autonomous agents.
+  - [runlet](https://github.com/DMIAOCHEN/runlet) - A tiny observable runtime for Python agents.
   - [pydantic-ai](https://github.com/pydantic/pydantic-ai) - A Python agent framework for building generative AI applications with structured schemas.
   - [TradingAgents](https://github.com/TauricResearch/TradingAgents) - A multi-agents LLM financial trading framework.
 - Data Layer


### PR DESCRIPTION
## What is this project?

[runlet](https://github.com/DMIAOCHEN/runlet) - A tiny observable runtime for Python agents.

- **Provider-neutral** — works with any LLM provider
- **Zero required dependencies**
- **MIT licensed**
- Available on PyPI: `pip install runlet`

## Checklist

- [x] Only one project in this PR
- [x] Entry is in alphabetical order within its category
- [x] Use PyPI package name as display name
- [x] GitHub repo URL used
- [x] Description ends with a period