### PR TITLE
Add zvec to Database section

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ _Databases implemented in Python._
 - [pickledb](https://github.com/patx/pickledb) - A simple and lightweight key-value store for Python.
 - [tinydb](https://github.com/msiemens/tinydb) - A tiny, document-oriented database.
 - [ZODB](https://github.com/zopefoundation/ZODB) - A native object database for Python. A key-value and object graph database.
+- [zvec](https://github.com/alibaba/zvec) - An embedded vector database for on-device RAG and edge AI, the SQLite of vector databases.
 
 ### Caching
 


### PR DESCRIPTION
## Project: [zvec](https://github.com/alibaba/zvec)

Zvec is an open-source embedded vector database by Alibaba Tongyi Lab, bringing SQLite-like simplicity to vector search. It runs in-process with zero external dependencies — just `pip install zvec`.

### Why it belongs here

- ✅ **Python-first**: `pip install zvec`, full Python SDK (3.10–3.14)
- ✅ **Actively maintained**: latest release v0.5.1 (June 24, 2026)
- ✅ **Production-ready**: built on Alibaba battle-tested Proxima engine
- ✅ **12,500+ GitHub stars** (Rising Star tier, 5x the 5,000-star threshold)
- ✅ **Clear README** with examples and documentation
- ✅ **Distinct value**: fills the "SQLite of vector databases" niche — embedded, serverless, zero-config, unlike existing client-server entries
- ✅ **Repository age**: open-sourced Feb 2026 (> 30 days)
- ✅ **Similar precedent**: chromadb is already listed in this section