### PR TITLE
Add buridan/ui to Web Based section

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,6 +854,7 @@ _Libraries for working with graphical user interface applications._
   - [toga](https://github.com/beeware/toga) - A Python native, OS native GUI toolkit.
   - [wxPython](https://github.com/wxWidgets/Phoenix) - A blending of the wxWidgets C++ class library with the Python.
 - Web-based
+  - [buridan/ui](https://github.com/LineIndent/ui) - Composable, themeable components designed for Reflex. Extend, override, and ship without fighting the framework. Open source. 
   - [flet](https://github.com/flet-dev/flet) - Cross-platform GUI framework for building modern apps in pure Python.
   - [nicegui](https://github.com/zauberzeug/nicegui) - An easy-to-use, Python-based UI framework, which shows up in your web browser.
   - [pywebview](https://github.com/r0x0r/pywebview/) - A lightweight cross-platform native wrapper around a webview component.


### PR DESCRIPTION

buridan/ui is a composable, themeable UI component library for the Reflex web framework, inspired by shadcn/ui and built entirely in Python. 

It provides reusable components and a design system for building consistent web UIs in Reflex-based applications, with CLI tooling and a token-based theming system.

## Project

[buridan/ui](https://github.com/LineIndent/ui)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

## How It Differs

A shadcn/ui-inspired component library for the Reflex web framework, providing a customizable design system and CLI-based component workflow.
