### PR TITLE
Improve project detail expansion performance

### DIFF
--- a/website/static/main.js
+++ b/website/static/main.js
@@ -119,6 +119,9 @@ rows.forEach(function (row, i) {
     next = next.nextElementSibling;
   }
   row._expandRow = next;
+  if (row._descRow) {
+    row.classList.toggle("has-visible-desc", !row._descRow.hidden);
+  }
 });
 
 function collapseAll() {
@@ -165,6 +168,7 @@ function applyFilters() {
       if (row._descRow.hidden !== descHidden) {
         row._descRow.hidden = descHidden;
       }
+      row.classList.toggle("has-visible-desc", !descHidden);
     }
 
     if (show) {

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -790,7 +790,7 @@ kbd {
   box-shadow: inset 3px 0 0 var(--accent);
 }
 
-.row:has(+ .desc-row:not([hidden])) td {
+.row.has-visible-desc td {
   border-bottom-color: transparent;
   padding-bottom: 0.35rem;
 }
@@ -1000,7 +1000,9 @@ th[data-sort].sort-asc::after {
   text-wrap: pretty;
   overflow-wrap: break-word;
   word-break: break-word;
+  content-visibility: auto;
   contain: layout style paint;
+  contain-intrinsic-size: auto 5rem;
   animation: expand-in 220ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 


### PR DESCRIPTION
## What Changed

This PR replaces the inline project detail expansion with a fixed detail panel.

- Desktop: project details open in a right-side panel.
- Mobile: project details open as a bottom drawer.
- The selected table row keeps a highlighted state.
- Sorting and filtering close the active detail panel to keep state consistent.

<img width="2549" height="1403" alt="ScreenShot_Effect_Preview" src="https://github.com/user-attachments/assets/c9729461-bf61-40c9-8c57-84ac11157aea" />

## Problem

The previous inline expansion inserted detail content directly into the table flow.

On large tables, expanding rows near the top could cause noticeable lag because the browser had to recalculate layout for many following rows. This was especially visible when interacting with early rows in the list.

## Why This Approach

The new fixed detail panel avoids changing the table height when a project is opened.

This reduces layout work while preserving the same project detail content and keeping the main table visually stable.

## Interaction And Accessibility

- Mouse click opens and closes project details.
- Enter / Space opens project details from a focused row.
- Escape closes the active detail panel.
- Keyboard-opened panels move focus to the close button.
- Closing with Escape returns focus to the selected row.
- `aria-expanded`, `aria-controls`, and `aria-labelledby` are updated for the panel interaction.

## Responsive Behavior

- On desktop, details appear in a right-side panel.
- On smaller screens, details appear as a bottom drawer.
- Reduced-motion users do not get the panel transition animation.

## Validation

- `uv run python website/build.py`
- `uv run pytest website/tests/ -v`
- `uv run ruff check .`