### PR TITLE
Update kreuzberg entry to xberg (renamed, 97+ formats)

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,7 +912,7 @@ _Libraries for parsing and manipulating specific text formats._
 
 - General
   - [docling](https://github.com/docling-project/docling) - Library for converting documents into structured data.
-  - [kreuzberg](https://github.com/xberg-io/xberg) - High-performance document extraction library with a Rust core, supporting 62+ formats including PDF, Office, images with OCR, HTML, email, and archives.
+  - [xberg](https://github.com/xberg-io/xberg) - High-performance document intelligence library with a Rust core, extracting text, tables, and metadata from 97+ formats including PDF, Office, images (with OCR), HTML, email, and archives.
   - [pyelftools](https://github.com/eliben/pyelftools) - Parsing and analyzing ELF files and DWARF debugging information.
   - [tablib](https://github.com/jazzband/tablib) - A module for Tabular Datasets in XLS, CSV, JSON, YAML.
 - MS Office


### PR DESCRIPTION
Updates the existing entry: the project was renamed `kreuzberg` → `xberg` (the repo now lives at `github.com/xberg-io/xberg`), and format coverage grew from 62+ to 97+. This refreshes the link text and description to match the current project name and scope. Same repository, same MIT license.
