### PR TITLE
Add spikard to Web Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ _Traditional full stack web frameworks. Also see [Web APIs](#web-apis)._
   - [microdot](https://github.com/miguelgrinberg/microdot) - The impossibly small web framework for Python and MicroPython.
   - [reflex](https://github.com/reflex-dev/reflex) - A framework for building reactive, full-stack web applications entirely with Python.
   - [robyn](https://github.com/sparckles/Robyn) - A high-performance async Python web framework with a Rust runtime.
+  - [spikard](https://github.com/Goldziher/spikard) - An ultra-fast, non-ASGI web framework with a Rust core and type-safe routing.
   - [starlette](https://github.com/Kludex/starlette) - A lightweight ASGI framework and toolkit for building high-performance async services.
   - [tornado](https://github.com/tornadoweb/tornado) - A web framework and asynchronous networking library.
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ _Traditional full stack web frameworks. Also see [Web APIs](#web-apis)._
   - [microdot](https://github.com/miguelgrinberg/microdot) - The impossibly small web framework for Python and MicroPython.
   - [reflex](https://github.com/reflex-dev/reflex) - A framework for building reactive, full-stack web applications entirely with Python.
   - [robyn](https://github.com/sparckles/Robyn) - A high-performance async Python web framework with a Rust runtime.
-  - [spikard](https://github.com/Goldziher/spikard) - An ultra-fast, non-ASGI web framework with a Rust core and type-safe routing.
+  - [spikard](https://github.com/Goldziher/spikard) - A high-performance non-ASGI web framework with a Rust core, generating typed handlers from OpenAPI, GraphQL, and SQL specs.
   - [starlette](https://github.com/Kludex/starlette) - A lightweight ASGI framework and toolkit for building high-performance async services.
   - [tornado](https://github.com/tornadoweb/tornado) - A web framework and asynchronous networking library.
 


### PR DESCRIPTION
### Add [spikard](https://github.com/Goldziher/spikard)

**Category:** Web Frameworks

A single project, per the one-project-per-PR guideline.

**Why it qualifies:**

- **115 GitHub stars**, MIT-licensed, actively maintained (commits within the last few days), repository ~16 months old.
- **Fastest Python framework in our benchmark suite.** 31 workloads via `oha` at concurrency 100, run by CI: spikard 12,623 avg RPS vs litestar 8,032, fastapi 6,418, robyn 6,012 — roughly 2x FastAPI and 2.1x Robyn, up to 2.7x on validation-heavy workloads. Results, per-category breakdown and the harness are in-repo.
- **Distinct value:** codegen-first and non-ASGI. Instead of writing Python and emitting an OpenAPI document from it, you start from a spec (OpenAPI 3.0, AsyncAPI 3.0, GraphQL SDL, OpenRPC, Protobuf) or from annotated SQL, and it generates typed handlers and validators. Routing, validation and middleware live in a Rust core; the Python layer is a thin binding.
- Clear README with installation and usage examples, plus a documentation site at [spikard.dev](https://spikard.dev).

Python-first in API with a Rust core — the same architecture as the already-listed [robyn](https://github.com/sparckles/Robyn) and [xberg](https://github.com/xberg-io/xberg) entries.

**Maturity, stated plainly:** an earlier version of this description called spikard "production-ready". That was wrong and I have corrected it. The project is **experimental and pre-1.0** (`0.17.0-rc`), and its README says so — APIs still change between releases. If the "Stable — not alpha/beta/experimental" requirement is applied strictly then it does not qualify yet, and I am happy for this to be closed and resubmitted after 1.0.
