### PR TITLE
Add backon - modern retry/backoff library (Hidden Gem)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,6 +1147,7 @@ _Python programming on Microsoft Windows._
 
 _Useful libraries or tools that don't fit in the categories above._
 
+- [backon](https://github.com/Llucs/backon) - Function decoration for backoff and retry — modern, fast, zero dependencies.
 - [blinker](https://github.com/pallets-eco/blinker) - A fast Python in-process signal/event dispatching system.
 - [boltons](https://github.com/mahmoud/boltons) - A set of pure-Python utilities.
 - [itsdangerous](https://github.com/pallets/itsdangerous) - Various helpers to pass trusted data to untrusted environments.


### PR DESCRIPTION
## Add backon to Miscellaneous

**Category:** Hidden Gem

**Repo:** https://github.com/Llucs/backon
**PyPI:** https://pypi.org/project/backon/

### Justification

backon is a modern evolution of the [backoff](https://github.com/litl/backoff) library (2,700+ stars), which is archived and no longer maintained. backon provides:

- **Zero dependencies** — pure Python, stdlib only
- **Four APIs** — decorator, functional, context manager, callable
- **Async native** — same API works for `async def` functions
- **Full type hints** — validated with mypy, strict mode compatible
- **Circuit breaker** — CLOSED/OPEN/HALF_OPEN states with automatic recovery
- **Hedging** — concurrent retry requests, first-success-wins
- **Prometheus / OpenTelemetry metrics** — optional, zero hard dependencies
- **Testing module** — disable_retries(), limit_retries(), remove_backoff()
- **Trio support** — retry with the trio async framework
- **Iterator API** — for attempt in Retrying(...)

It is the only actively maintained retry library that offers all of these features in a single package. The original backoff (2.7k stars) is archived, tenacity is in maintenance mode, and retrying has not been updated since 2021.

### Quality Checklist
- [x] Python-first: 100% Python
- [x] Active: commits within last 12 months (latest v3.7.0 Jul 1, 2026)
- [x] Stable: production-ready, multiple releases (v3.7.0)
- [x] Documented: comprehensive README with examples
- [x] Unique: only actively-maintained full-featured retry library for Python