### PR TITLE
Add crawlberg to Web Scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ _Libraries to automate web scraping and extract web content._
 - Frameworks
   - [browser-use](https://github.com/browser-use/browser-use) - Make websites accessible for AI agents with easy browser automation.
   - [crawl4ai](https://github.com/unclecode/crawl4ai) - An open-source, LLM-friendly web crawler that provides lightning-fast, structured data extraction specifically designed for AI agents.
+  - [crawlberg](https://github.com/xberg-io/crawlberg) - A high-performance web crawling engine with a Rust core, headless-browser fallback, and built-in robots.txt and sitemap parsing.
   - [mechanicalsoup](https://github.com/MechanicalSoup/MechanicalSoup) - A Python library for automating interaction with websites.
   - [scrapy](https://github.com/scrapy/scrapy) - A fast high-level screen scraping and web crawling framework.
 - Content Extraction


### PR DESCRIPTION
### Add [crawlberg](https://github.com/xberg-io/crawlberg)

**Category:** Web Scraping → Frameworks

Single project, per the one-project-per-PR guideline.

**Why it qualifies:**
- **120+ GitHub stars**, MIT-licensed, and actively maintained (commits within the last few days).
- Production-ready release on PyPI with a clear README containing installation and usage examples.
- **Distinct value:** A Rust-core crawling engine (not a wrapper around requests/Playwright) with a headless-browser fallback and native robots.txt/sitemap handling, offering a different performance profile from the existing pure-Python entries.

It is a Python-first library (installable from PyPI) with a Rust core for performance — the same architecture as the already-listed [xberg](https://github.com/xberg-io/xberg) entry.
