### PR TITLE
Add html-to-markdown to HTML Manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ _Libraries for parsing and manipulating plain texts._
 _Libraries for working with HTML and XML._
 
 - [beautifulsoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) - Providing Pythonic idioms for iterating, searching, and modifying HTML or XML.
+- [html-to-markdown](https://github.com/xberg-io/html-to-markdown) - A fast, CommonMark-compliant HTML to Markdown converter with a Rust core, tolerant of malformed HTML.
 - [justhtml](https://github.com/EmilStenstrom/justhtml/) - A pure Python HTML5 parser that just works.
 - [lxml](https://github.com/lxml/lxml) - A very fast, easy-to-use and versatile library for handling HTML and XML.
 - [markupsafe](https://github.com/pallets/markupsafe) - Implements a XML/HTML/XHTML Markup safe string for Python.


### PR DESCRIPTION
### Add [html-to-markdown](https://github.com/xberg-io/html-to-markdown)

**Category:** HTML Manipulation

Single project, per the one-project-per-PR guideline.

**Why it qualifies:**
- **793+ GitHub stars**, MIT-licensed, and actively maintained (commits within the last few days).
- Production-ready release on PyPI with a clear README containing installation and usage examples.
- **Distinct value:** A dedicated, CommonMark-compliant HTML→Markdown converter with a Rust core that is robust against malformed HTML — distinct from the general HTML/XML parsers already listed in this category.

It is a Python-first library (installable from PyPI) with a Rust core for performance — the same architecture as the already-listed [xberg](https://github.com/xberg-io/xberg) entry.
