### PR TITLE
Add liter-llm to AI and Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
 - Pre-trained Models and Inference
   - [diffusers](https://github.com/huggingface/diffusers) - A library that provides pre-trained diffusion models for generating and editing images, audio, and video.
   - [LiteLLM](https://github.com/BerriAI/litellm) - Call 100+ LLMs using OpenAI format.
+  - [liter-llm](https://github.com/xberg-io/liter-llm) - A universal LLM API client with a Rust core, calling 142+ providers through a single OpenAI-compatible interface, with a built-in proxy and MCP server.
   - [mlx-lm](https://github.com/ml-explore/mlx-lm) - Run and fine-tune large language models on Apple Silicon with MLX.
   - [sglang](https://github.com/sgl-project/sglang) - A high-performance serving framework for large language models and multimodal models.
   - [transformers](https://github.com/huggingface/transformers) - A framework that lets you easily use pre-trained transformer models for NLP, vision, and audio tasks.


### PR DESCRIPTION
### Add [liter-llm](https://github.com/xberg-io/liter-llm)

**Category:** AI and Agents → Pre-trained Models and Inference

Single project, per the one-project-per-PR guideline.

**Why it qualifies:**
- **222+ GitHub stars**, MIT-licensed, and actively maintained (commits within the last few days).
- Production-ready release on PyPI with a clear README containing installation and usage examples.
- **Distinct value:** A Rust-core universal LLM client covering 142+ providers behind one OpenAI-compatible interface, additionally shipping an OpenAI-compatible proxy and an MCP server, with native bindings across multiple languages.

It is a Python-first library (installable from PyPI) with a Rust core for performance — the same architecture as the already-listed [xberg](https://github.com/xberg-io/xberg) entry.
