### PR TITLE
Add enlil to AI and Agents > Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [bub](https://github.com/bubbuild/bub) - A lightweight, hook-first Python framework for channel-native agents that live alongside people.
   - [crewai](https://github.com/crewAIInc/crewAI) - A framework for orchestrating role-playing autonomous AI agents for collaborative task solving.
   - [dspy](https://github.com/stanfordnlp/dspy) - A framework for programming, not prompting, language models.
+  - [enlil](https://github.com/conchaestradamiguelangel-droid/enlil) - A self-hosted multi-agent LLM council where 9 AI models deliberate in parallel on every query, producing a post-quantum signed consensus output (ML-DSA-87, NIST FIPS 204). BYOK, GPL-3.0.
   - [hermes-agent](https://github.com/nousresearch/hermes-agent) - An adaptive AI agent framework that grows with you.
   - [langchain](https://github.com/langchain-ai/langchain) - Building applications with LLMs through composability.
   - [langgraph](https://github.com/langchain-ai/langgraph) - Low-level orchestration framework for building stateful, long-running LLM agents.


### PR DESCRIPTION
Adding [ENLIL](https://github.com/conchaestradamiguelangel-droid/enlil) to the **AI and Agents > Orchestration** section.

ENLIL is a self-hosted multi-agent LLM deliberation council: 9 AI models receive the same query simultaneously, reason independently, and produce a synthesized consensus. What makes it unique: every output is cryptographically signed with ML-DSA-87 (NIST FIPS 204 post-quantum standard) — making it the first LLM orchestration framework with verifiable, quantum-resistant output signatures.

- BYOK (any OpenRouter model), GPL-3.0, FastAPI + React
- Live: https://enlil-council.com/dashboard
- Source: https://github.com/conchaestradamiguelangel-droid/enlil