### PR TITLE
Add issuebeam to AI and Agents / Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [funasr](https://github.com/modelscope/FunASR) - Industrial-grade speech recognition toolkit with 170x realtime speed, 50+ languages, speaker diarization, and emotion detection.
   - [vibevoice](https://github.com/microsoft/VibeVoice) - A family of open-source voice AI models from Microsoft for text-to-speech and long-form speech recognition.
   - [voxcpm](https://github.com/OpenBMB/VoxCPM) - A tokenizer-free text-to-speech foundation model for multilingual speech generation and voice cloning.
+  - [issuebeam](https://github.com/issuebeam/issuebeam) - Gives AI coding agents (Cursor, Claude Code, Copilot) the skill to create and manage GitHub Issues directly.
+
 
 ### Deep Learning
 


### PR DESCRIPTION
## Project

[issuebeam](https://github.com/issuebeam/issuebeam)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:
issuebeam solves a very specific, real friction point elegantly: AI coding agents (Cursor, Claude Code, Copilot) have no way to interact with GitHub Issues, so bugs and tasks mentioned mid-session get lost the moment the chat context clears. Rather than building a new dashboard or tracker, issuebeam is a tiny CLI, written entirely in Python's standard library (no dependencies, no `gh` CLI), that any AI agent can execute on any OS the moment it's dropped into a repo, paired with ready-made instructions (`AGENTS.md`) that teach the agent how to use it.

## How It Differs

If similar entries exist, what makes this one unique?

Unlike other entries in this section that add skills for a specific vendor's own product (e.g. sentry-skills, trailofbits-skills), issuebeam is vendor-agnostic and targets the one thing almost every repo already has: GitHub Issues. Its main technical differentiator is the zero-dependency design — it's built so an *agent*, not a human, can run it reliably on any machine without an install step, which is a different design goal than most human-facing CLI tools.
