### PR TITLE
Add BDE Score - AI stock analysis tool to Financial Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ _Libraries for data extraction, transformation, and loading pipelines across mul
   - [lumibot](https://github.com/Lumiwealth/lumibot) - Algorithmic trading framework for backtesting and live deployment across stocks, options, crypto, futures, and forex.
   - [openbb](https://github.com/OpenBB-finance/OpenBB) - A financial data platform for analysts, quants and AI agents.
   - [yfinance](https://github.com/ranaroussi/yfinance) - Easy Pythonic way to download market and financial data from Yahoo Finance.
+  - [bde-score](https://github.com/hbhqq9/bde-score) - AI-powered multi-market stock analysis with transparent BDE scoring across 73 stocks (US/HK/A-share). EU AI Act Art.50 compliant.
 
 ### Data Validation
 


### PR DESCRIPTION
Adding BDE Score to the Data Ingestion / ETL > Financial Data section. BDE Score is an AI-powered multi-market stock analysis tool with transparent BDE scoring across 73 stocks (US/HK/A-share). EU AI Act Art.50 compliant. MIT license. GitHub: https://github.com/hbhqq9/bde-score