### PR TITLE
Add website-downloader (Web Scraping / Frameworks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ _Libraries to automate web scraping and extract web content._
   - [crawlberg](https://github.com/xberg-io/crawlberg) - A high-performance web crawling engine with a Rust core, headless-browser fallback, and built-in robots.txt and sitemap parsing.
   - [mechanicalsoup](https://github.com/MechanicalSoup/MechanicalSoup) - A Python library for automating interaction with websites.
   - [scrapy](https://github.com/scrapy/scrapy) - A fast high-level screen scraping and web crawling framework.
+  - [website-downloader](https://github.com/PKHarsimran/website-downloader) - A modern wget --mirror / HTTrack alternative that saves entire websites as browsable offline copies, with JavaScript rendering, incremental updates, and zip/WARC export.
 - Content Extraction
   - [feedparser](https://github.com/kurtmckee/feedparser) - Universal feed parser.
   - [html2text](https://github.com/Alir3z4/html2text) - Convert HTML to Markdown-formatted text.

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ _Libraries to automate web scraping and extract web content._
   - [crawlberg](https://github.com/xberg-io/crawlberg) - A high-performance web crawling engine with a Rust core, headless-browser fallback, and built-in robots.txt and sitemap parsing.
   - [mechanicalsoup](https://github.com/MechanicalSoup/MechanicalSoup) - A Python library for automating interaction with websites.
   - [scrapy](https://github.com/scrapy/scrapy) - A fast high-level screen scraping and web crawling framework.
-  - [website-downloader](https://github.com/PKHarsimran/website-downloader) - A modern wget --mirror / HTTrack alternative that saves entire websites as browsable offline copies, with JavaScript rendering, incremental updates, and zip/WARC export.
+  - [website-downloader](https://github.com/PKHarsimran/website-downloader) - A modern wget --mirror / HTTrack alternative that turns whole websites into browsable offline copies.
 - Content Extraction
   - [feedparser](https://github.com/kurtmckee/feedparser) - Universal feed parser.
   - [html2text](https://github.com/Alir3z4/html2text) - Convert HTML to Markdown-formatted text.


### PR DESCRIPTION
Adding `website-downloader` under **Web Scraping → Frameworks**.

**Acceptance criterion: Hidden Gem.**
- **147 stars, 37 forks** — within the preferred 100–500 range.
- **~24 months old** (created July 2024) with consistent activity — releases through v2.6.1, commits this month.
- **Real-world usage:** e.g. a user recently reported and received a same-day fix for mirroring OpenProject wiki attachments ([issue #49](https://github.com/PKHarsimran/website-downloader/issues/49)).
- **On PyPI:** `pip install website-downloader` (v2.6.1).

**Distinct value (not "yet another scraper"):** unlike the data-extraction frameworks already listed (scrapy, crawl4ai, trafilatura), this is a whole-site *mirroring* tool — a modern, hackable alternative to `wget --mirror` / HTTrack. It downloads pages + assets and rewrites links for offline browsing, handling modern markup (`srcset`, lazy assets, CSS `@import`), optional JS rendering via Playwright, incremental `ETag`/`Last-Modified` updates, and zip/WARC export.

Single project, standard format, alphabetical order, uses the PyPI package name, no duplicate of any existing or prior entry.