### PR TITLE
Add fluxcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,7 @@ _Libraries for manipulating audio, video, and their metadata._
   - [matchering](https://github.com/sergree/matchering) - A library for automated reference audio mastering.
   - [pydub](https://github.com/jiaaro/pydub) - Manipulate audio with a simple and easy high level interface.
 - Video
+  - [fluxcast](https://github.com/IlyaP358/fluxcast) - Stream Linux desktop and audio to Smart TVs via Miracast/WFD, DLNA, or Chromecast, supporting Wayland (wlroots, GNOME, KDE).
   - [moviepy](https://github.com/Zulko/moviepy) - A module for script-based movie editing with many formats, including animated GIFs.
   - [vidgear](https://github.com/abhiTronix/vidgear) - Most Powerful multi-threaded Video Processing framework.
 - Metadata


### PR DESCRIPTION
## Project

[fluxcast](https://github.com/IlyaP358/fluxcast)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

Screencasting from Linux to a Smart TV (especially over modern Wayland/wlroots, GNOME, or KDE environments) is a well-known pain point for Linux users. FluxCast elegantly solves this by providing a reliable Python-based tool that supports Miracast/WFD, DLNA, and Chromecast along with audio capturing. It is highly polished, packaged (PyPI, AppImage, AUR), has great documentation, and is actively maintained with 290+ stars.

## How It Differs

Most other tools in the "Audio & Video" section are libraries for media processing (like MoviePy or VidGear). FluxCast is a complete, ready-to-use utility specifically tailored for real-time Linux desktop and audio streaming. Unlike older tools (miraclecast & gnome-network-displays), it fully supports modern Wayland pipelines (PipeWire/xdg-desktop-portal) alongside classic X11.