### PR TITLE
Add instrumation to Hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ _Libraries for programming with hardware._
 - [jumpstarter](https://github.com/jumpstarter-dev/jumpstarter) - A hardware-in-the-loop testing framework with a Python client library for automated testing on real and virtual hardware.
 - [pynput](https://github.com/moses-palmer/pynput) - A library to control and monitor input devices.
 - [synology-api](https://github.com/N4S4/synology-api) - Python wrapper for Synology NAS APIs: Surveillance Station, File Station, Download Station, Docker, and 50+ other endpoints.
+- [instrumation](https://github.com/abduznik/instrumation) - A high-level Hardware Abstraction Layer for RF test stations with Digital Twin support, auto-discovery, and typed multi-vendor instrument APIs.
 
 ### Microsoft Windows
 


### PR DESCRIPTION
Hidden Gem justification: Instrumation fills a gap none of the current Hardware section entries address: RF test station automation. While PyVISA provides low-level VISA transport and PyMeasure targets scientific measurement, Instrumation combines a multi-vendor RF instrument HAL with Digital Twin simulation and automatic bus discovery — capabilities no existing Python library offers in a single package. It has been validated against real Keysight, Tektronix, and Rohde & Schwarz hardware, with published experiment reports (VNA S-parameters, spectrum analyzer traces, signal generator sweeps). The project has 88 GitHub stars, 7k+ total PyPI downloads, and active contributions from external users including interest from a Keysight applications engineer. Development is active (latest commit this week, v0.5.0 released on PyPI, MIT licensed). It belongs in the Hardware section because it is a Python library for programming with hardware — specifically test and measurement instruments — and its RF-focused HAL + Digital Twin combination distinguishes it from the general-purpose tools already listed.