### PR TITLE
Add hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1078,6 +1078,7 @@ _Libraries for Python version and virtual environment management._
 _Libraries for package and dependency management._
 
 - [conda](https://github.com/conda/conda/) - Cross-platform, Python-agnostic binary package manager.
+- [hatch](https://github.com/pypa/hatch) - Modern, extensible Python project manager for environments, builds, and publishing.
 - [pip](https://github.com/pypa/pip) - The package installer for Python.
 - [pipx](https://github.com/pypa/pipx) - Install and Run Python Applications in Isolated Environments. Like `npx` in Node.js.
 - [poetry](https://github.com/python-poetry/poetry) - Python dependency management and packaging made easy.


### PR DESCRIPTION
## Project

[hatch](https://github.com/pypa/hatch)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [x] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [ ] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:
Hatch is the official project manager maintained by the PyPA (Python Packaging Authority). It is production-ready, actively maintained, written in Python, and widely used for managing environments, builds, and publishing packages.

## How It Differs

Unlike pip/pipx (installers) and poetry/uv (dependency managers), Hatch is a PyPA-maintained, standards-first project manager with a pluggable build backend (hatchling), matrix environment management, and built-in publishing — it complements rather than duplicates the existing entries.

#HSFDPMUW
