### PR TITLE
docs: add pystreamliner to Code Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ _Tools of static analysis, linters and code quality checkers. Also see [awesome-
 - Code Analysis
   - [code2flow](https://github.com/scottrogowski/code2flow) - Turn your Python and JavaScript code into DOT flowcharts.
   - [prospector](https://github.com/prospector-dev/prospector) - A tool to analyze Python code.
+  - [pystreamliner](https://github.com/salesforce/pystreamliner) - A tool for identifying and removing code duplication in Python projects.
   - [repowise](https://github.com/repowise-dev/repowise) - Codebase intelligence that indexes repos into dependency graphs, git history, and auto-generated docs with dead code detection.
   - [vulture](https://github.com/jendrikseipp/vulture) - A tool for finding and analyzing dead Python code.
 - Code Linters


### PR DESCRIPTION
Adds pystreamliner (Salesforce code-deduplication tool) to the Code Analysis section.

Fixes #3257