### PR TITLE
Add django-orm-lens under Debugging Tools > Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,7 @@ _Libraries for debugging code._
   - [scalene](https://github.com/plasma-umass/scalene) - A high-performance, high-precision CPU, GPU, and memory profiler for Python.
 - Others
   - [django-debug-toolbar](https://github.com/django-commons/django-debug-toolbar) - Display various debug information for Django.
+  - [django-orm-lens](https://github.com/FROWNINGdev/django-orm-lens) - Live sidebar and Mermaid ER diagram for your Django models plus a CLI and MCP server for AI agents. Static AST analysis — no DB, no Django boot.
   - [flask-debugtoolbar](https://github.com/pallets-eco/flask-debugtoolbar) - A port of the django-debug-toolbar to flask.
   - [icecream](https://github.com/gruns/icecream) - Inspect variables, expressions, and program execution with a single, simple function call.
   - [memory_graph](https://github.com/bterwijn/memory_graph) - Visualize Python data at runtime to debug references, mutability, and aliasing.


### PR DESCRIPTION
Adds [django-orm-lens](https://github.com/FROWNINGdev/django-orm-lens) to `Debugging Tools > Others` — the Django debugging neighbourhood alongside `django-debug-toolbar` and `django-migration-linter`-style tools.

## What it does

Static-analysis dev tool for Django ORM models. Zero database, zero Django boot, zero credentials — parses `models.py` / `signals.py` / `migrations/` via AST.

Three surfaces on one Python parser:
- **CLI** (`pip install django-orm-lens`) — 6 subcommands: `list`, `apps`, `describe`, `relations`, `nplusone`, `migration-risk`
- **MCP server** (`pip install django-orm-lens[mcp]`) — 9 read-only tools for AI coding agents (Cursor, Aider, Claude Desktop, Zed): `list_apps`, `list_models`, `describe_model`, `find_relations`, `cascade_preview`, `er_diagram`, `describe_migration_dependency`, `suggest_indexes`, `signal_graph`
- **VS Code / VSCodium / Cursor extension** — sidebar tree + Mermaid ER diagram + hover cards + CodeLens

## Quality checklist per CONTRIBUTING.md

- ✅ **Python-first** — 78.5% Python (313.5 KB), 17.8% TypeScript (VS Code webview only). Repo language breakdown: https://github.com/FROWNINGdev/django-orm-lens
- ✅ **Active** — 8 patch releases shipped today (v0.7.0 → v0.7.8), CI green
- ✅ **Stable** — v0.7.8, 5.0★ Marketplace rating, 185 Python + 4 TypeScript regression tests, all green
- ✅ **Documented** — README in EN/RU/ES/ZH, quickstart under 60 seconds, examples, gallery, roadmap
- ✅ **Unique** — the only Django-model static-analysis tool with all three surfaces (editor + CLI + MCP) sharing one parser. No existing awesome-python entry overlaps
- ⚠️ **Established** — repository is 9 days old (2026-07-12). This misses the 1-month base bar and the 3-month Hidden Gem bar. Fully understand if you want to hold and revisit; opening this PR mostly to put it on your radar and let you decide.

## Signals that partially compensate for age

- **Verified ✓** by the Eclipse Foundation on Open VSX (independent third-party validation): https://open-vsx.org/extension/frowningdev/django-orm-lens
- Listed in the official [Model Context Protocol Registry](https://registry.modelcontextprotocol.io/), on [Glama.ai](https://glama.ai/mcp/servers/FROWNINGdev/django-orm-lens), and on [mcp.so](https://mcp.so/servers/django-orm-lens)
- **7 community PRs merged in 9 days** — real external contribution signal, not a solo repo
- **Traction:** 636 Open VSX downloads · 286 VS Code MP downloads · 2,833 PyPI downloads / month · 14 ⭐ · 4 forks
- Featured in the [r/django Reddit community](https://reddit.com/r/django) — hit the top posts of the week
- 5.0★ VS Code Marketplace rating

## The entry (Debugging Tools > Others, alphabetically after `django-debug-toolbar`)

```markdown
- [django-orm-lens](https://github.com/FROWNINGdev/django-orm-lens) - Live sidebar and Mermaid ER diagram for your Django models plus a CLI and MCP server for AI agents. Static AST analysis — no DB, no Django boot.
```

Happy to close and revisit at 1-month / 3-month mark if you'd prefer the age bar respected. Please close without hesitation if that's the call — no hard feelings. Thanks for the amazing catalog!