### PR TITLE
Add lumen to AI and Agents > Data Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [entroly](https://github.com/juyterman1000/entroly) - An auditable context control plane that optimizes prompt context, stabilizes cache prefixes, and verifies answers locally with WITNESS.
   - [instructor](https://github.com/567-labs/instructor) - A library for extracting structured data from LLMs, powered by Pydantic.
   - [llama-index](https://github.com/run-llama/llama_index) - A data framework for your LLM application.
+  - [lumen](https://github.com/holoviz/lumen) - An agent framework for conversational analysis of SQL, dataframe and multidimensional array data.
   - [mem0](https://github.com/mem0ai/mem0) - An intelligent memory layer for AI agents enabling personalized interactions.
   - [outlines](https://github.com/dottxt-ai/outlines) - Structured text generation for LLMs with JSON schema, regex, and grammar-constrained decoding.
 - Pre-trained Models and Inference


### PR DESCRIPTION
Adds `lumen` to AI and Agents > Data Layer.

## Quality requirements

- **Python-first**: yes, pure Python built on Panel and DuckDB
- **Active**: commits today; releases in January, March and June 2026
- **Stable**: 1.2.1, classified `Development Status :: 5 - Production/Stable`
- **Documented**: https://lumen.holoviz.org with tutorials, configuration guides and API reference
- **Established**: repository created May 2020

## Acceptance criteria: Hidden Gem

Lumen is at roughly 300 stars, inside the 100-500 band described for this category.

**The gap it fills.** Data Layer currently covers documents and memory. `llama-index` is a data framework for LLM applications over documents, `mem0` is agent memory, `instructor` and `outlines` handle structured output. Nothing here covers conversational analysis of tabular and scientific data, which is a distinct problem: schema inspection, SQL generation, transformation pipelines and rendering.

**How it differs from text-to-SQL tools.** Those return a query string. Lumen returns a declarative specification, so a generated analysis can be version-controlled, reopened in a notebook, or composed into a dashboard. It also reads xarray and Zarr, so it works on multidimensional scientific data rather than only rows and columns.

**Real-world usage.** BSD-3-Clause, NumFOCUS-affiliated HoloViz project alongside Panel, HoloViews and Datashader. On PyPI as `lumen` and on conda-forge.

- Repo: https://github.com/holoviz/lumen
- Docs: https://lumen.holoviz.org
