### PR TITLE
Add tkdesigner to GUI libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,7 @@ _Libraries for working with graphical user interface applications._
   - [pygobject](https://github.com/GNOME/pygobject) - Python Bindings for GLib/GObject/GIO/GTK+ (GTK+3).
   - [PyQt](https://www.riverbankcomputing.com/static/Docs/PyQt6/) - Python bindings for the [Qt](https://www.qt.io/) cross-platform application and UI framework.
   - [pyside](https://github.com/pyside/pyside-setup) - Qt for Python offers the official Python bindings for [Qt](https://www.qt.io/), this is same as PyQt but it's the official binding with different licensing.
+  - [tkdesigner](https://github.com/ParthJadhav/Tkinter-Designer) - Generates Tkinter interfaces from Figma designs using the Figma API.
   - [tkinter](https://docs.python.org/3/library/tkinter.html) - (Python standard library) The standard Python interface to the Tcl/Tk GUI toolkit.
   - [toga](https://github.com/beeware/toga) - A Python native, OS native GUI toolkit.
   - [wxPython](https://github.com/wxWidgets/Phoenix) - A blending of the wxWidgets C++ class library with the Python.


### PR DESCRIPTION
## Project

[TkDesigner](https://github.com/ParthJadhav/Tkinter-Designer)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [x] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [ ] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

Tkinter-Designer creates functional Tkinter GUIs automatically by converting Figma designs into python code. It is fully unique in its method of being able to automatically port Figma files to code, essentially allowing developers to design lightweight interfaces visually.

## How It Differs

Tkinter-Designer uses the Figma API to automatically convert the design to python code, using the Figma file like and a Figma API token. This tool can either be used through a GUI or on a CLI.
