### PR TITLE
Add kaydet

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,6 +837,7 @@ _Useful CLI-based tools for productivity._
   - [cookiecutter](https://github.com/cookiecutter/cookiecutter) - A command-line utility that creates projects from cookiecutters (project templates).
   - [copier](https://github.com/copier-org/copier) - A library and command-line utility for rendering projects templates.
   - [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
+  - [kaydet](https://github.com/miratcan/kaydet) - Queryable personal database and terminal diary with SQLite search, tags, metadata, and AI integration via MCP.
   - [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
   - [tmuxp](https://github.com/tmux-python/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.
   - [xonsh](https://github.com/xonsh/xonsh/) - A Python-powered shell. Full-featured and cross-platform.


### PR DESCRIPTION
Add [kaydet](https://github.com/miratcan/kaydet) - a queryable personal database and terminal diary.

**Hidden Gem submission** (28 stars, below 100 threshold):

Kaydet is a unique CLI tool that combines a plain-text terminal diary with SQLite FTS5 full-text search, structured metadata queries (key:value with numeric comparisons), tag management, todo tracking, file attachments, and a built-in MCP server for AI assistant integration.

**Why it's awesome:**
- **Python-first:** 100% Python, 197 tests, production-ready
- **Unique value proposition:** Not just a diary - a queryable personal database with SQLite backend
- **Active development:** 3+ years of consistent commits, latest release v0.38.1 (July 2026)
- **Well documented:** Comprehensive README, file format spec, query syntax docs, contributing guide
- **AI integration:** Built-in MCP server exposes 13 tools to Claude Desktop and other AI assistants
- **Real-world usage:** 28 GitHub stars, Homebrew package, PyPI package with Trusted Publisher publishing

**Key differentiator:** Unlike most note-taking CLIs, kaydet stores entries as plain text files (git-friendly, no lock-in) while maintaining a SQLite FTS5 index for fast full-text and metadata search.