### PR TITLE
Add alterlab to Web Crawling and Web Scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ _Libraries for working with HTTP._
 _Libraries to automate web scraping and extract web content._
 
 - Frameworks
-  - [alterlab](https://github.com/RapierCraft/AlterLab-SDK) - Web scraping SDK with automatic anti-bot bypass, JavaScript rendering, and structured data extraction.
+  - [alterlab](https://github.com/RapierCraft/AlterLab-SDK) - Web scraping SDK with automatic website compatibility, JavaScript rendering, and structured data extraction.
   - [browser-use](https://github.com/browser-use/browser-use) - Make websites accessible for AI agents with easy browser automation.
   - [crawl4ai](https://github.com/unclecode/crawl4ai) - An open-source, LLM-friendly web crawler that provides lightning-fast, structured data extraction specifically designed for AI agents.
   - [crawlberg](https://github.com/xberg-io/crawlberg) - A high-performance web crawling engine with a Rust core, headless-browser fallback, and built-in robots.txt and sitemap parsing.

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ _Libraries for working with HTTP._
 _Libraries to automate web scraping and extract web content._
 
 - Frameworks
+  - [alterlab](https://github.com/RapierCraft/AlterLab-SDK) - Web scraping SDK with automatic anti-bot bypass, JavaScript rendering, and structured data extraction.
   - [browser-use](https://github.com/browser-use/browser-use) - Make websites accessible for AI agents with easy browser automation.
   - [crawl4ai](https://github.com/unclecode/crawl4ai) - An open-source, LLM-friendly web crawler that provides lightning-fast, structured data extraction specifically designed for AI agents.
   - [crawlberg](https://github.com/xberg-io/crawlberg) - A high-performance web crawling engine with a Rust core, headless-browser fallback, and built-in robots.txt and sitemap parsing.


### PR DESCRIPTION
Adds `alterlab` to **Web Crawling and Web Scraping**.

[AlterLab-SDK](https://github.com/RapierCraft/AlterLab-SDK) is the official Python SDK for the AlterLab web data API.

- `pip install alterlab` — https://pypi.org/project/alterlab/
- Six modes: scrape, crawl, search, map, extract, and authenticated sessions
- Returns markdown, JSON, text, HTML, screenshots, or PDF
- Automatic website compatibility, JS rendering, and challenge resolution
- MIT licensed, actively maintained

Inserted alphabetically within the section. Happy to reword or relocate the entry if you'd prefer.
