### PR TITLE
Add DepTend

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ _Tools of static analysis, linters and code quality checkers. Also see [awesome-
 
 - Code Analysis
   - [code2flow](https://github.com/scottrogowski/code2flow) - Turn your Python and JavaScript code into DOT flowcharts.
+  - [DepTend](https://github.com/SpIob/DepTend) - Scans a repo's PyPI dependencies against the OSV database and ranks what to fix first, with the full scoring breakdown shown for every result.
   - [prospector](https://github.com/prospector-dev/prospector) - A tool to analyze Python code.
   - [repowise](https://github.com/repowise-dev/repowise) - Codebase intelligence that indexes repos into dependency graphs, git history, and auto-generated docs with dead code detection.
   - [vulture](https://github.com/jendrikseipp/vulture) - A tool for finding and analyzing dead Python code.


### PR DESCRIPTION
Added DepTend to the list of code analysis tools.

## Project
[DepTend](https://github.com/SpIob/DepTend)

## Checklist
- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome
Which criterion does it meet? (pick one)
- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:
DepTend just launched, so I want to be upfront that it doesn't have traction numbers to point to yet. What it does have: it takes a repo's dependencies, checks them against OSV, and turns the result into a ranked, fully explainable list of maintenance work, not just a severity number. Every score shows its source advisory and its scoring inputs one click away, and confidence is flagged honestly rather than hidden when an input is missing. It runs entirely on free-tier infrastructure with no account needed to browse. If "hidden gem" doesn't fit a brand-new project by your standards, I understand if this gets held for more history first, happy to resubmit once there's real usage to show.

## How It Differs
The closest existing entries in Code Analysis (`code2flow`, `prospector`, `repowise`, `vulture`) all analyze a codebase's structure or dead code. None of them score dependencies for known vulnerabilities or rank what to fix first. DepTend is also cross-ecosystem (npm, PyPI, Go) from one scoring method, and its public rescue board lets someone who isn't the maintainer claim a specific fix, closer to a bounty board than a private alert inbox.
