### PR TITLE
Add smolagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [OpenChronicle](https://github.com/Einsia/OpenChronicle) - Open-source, local-first memory for any tool-capable LLM agent.
   - [promptise](https://github.com/promptise-com/foundry) - A framework for building end-to-end production-ready agentic systems, scalable & secure MCP's and autonomous agents.
   - [pydantic-ai](https://github.com/pydantic/pydantic-ai) - A Python agent framework for building generative AI applications with structured schemas.
+  - [smolagents](https://github.com/huggingface/smolagents) - A lightweight library to build agents and multi-agent workflows with minimal code.
   - [TradingAgents](https://github.com/TauricResearch/TradingAgents) - A multi-agents LLM financial trading framework.
 - Data Layer
   - [entroly](https://github.com/juyterman1000/entroly) - An auditable context control plane that optimizes prompt context, stabilizes cache prefixes, and verifies answers locally with WITNESS.


### PR DESCRIPTION
Add [smolagents](https://github.com/huggingface/smolagents) to **AI and Agents → Orchestration**.

**Why it qualifies (CONTRIBUTING.md — Rising Star)**
- **Python-first**, open-source (Hugging Face), actively maintained with frequent commits.
- **Rapid adoption**: released Dec 2024 and quickly surpassed 20k+ GitHub stars — well above the 5,000+ in < 1 year Rising Star bar.
- **Stable & documented**: production-ready, clear README with examples; widely used for building agents and multi-agent pipelines.
- **Distinct value**: a deliberately minimal, lightweight agent framework (contrasts with heavier orchestration stacks), fitting naturally alongside `autogen`, `langchain`, `crewai`, and `pydantic-ai` already listed.

**Format compliance**
- Display name uses the PyPI package name `smolagents`; link points to the GitHub repo.
- Entry placed alphabetically within *Orchestration* (between `pydantic-ai` and `TradingAgents`).
- Description ends with a period; 2-space subcategory indentation matches the existing style.
- Only one link added; no existing entry modified.

Link returns HTTP 200 and the change is a single line addition.