### PR TITLE
Add msgspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ _Libraries for serializing complex data types._
 
 - [marshmallow](https://github.com/marshmallow-code/marshmallow) - A lightweight library for converting complex objects to and from simple Python datatypes.
 - [msgpack](https://github.com/msgpack/msgpack-python) - MessagePack serializer implementation for Python.
+- [msgspec](https://github.com/msgspec/msgspec) - A fast serialization and validation library with built-in support for JSON, MessagePack, YAML, and TOML.
 - [orjson](https://github.com/ijl/orjson) - Fast, correct JSON library.
 
 **Data & Science**


### PR DESCRIPTION
## Project

[msgspec](https://github.com/msgspec/msgspec)

## Checklist

- [x] One project per PR
- [x] PR title format: Add project-name
- [x] Entry follows the required format and ends with a period
- [x] Description is concise and short

## Why This Project Is Awesome

**Hidden Gem** — msgspec is an established, actively maintained, Python-first library for typed serialization and validation. The upstream project has 3,960 GitHub stars, a BSD-3-Clause license, and a current 0.21.1 release. It supports JSON, MessagePack, YAML, and TOML while using Python type annotations for schema validation, giving readers a distinct option beyond the existing general-purpose and protocol-specific serialization entries.

## How It Differs

- marshmallow focuses on converting complex objects to and from simple Python data.
- msgpack provides the MessagePack serializer implementation.
- orjson is a fast JSON library.
- msgspec combines high-performance multi-protocol serialization with typed validation and structured data types.

The current README has no msgspec entry, and the repository search found no existing dedicated msgspec pull request.