### PR TITLE
Add basilisk-python to Code Analysis / Type Checkers (100% PEP Conformance According to Python/typing repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ _Tools of static analysis, linters and code quality checkers. Also see [awesome-
 - Refactoring
   - [rope](https://github.com/python-rope/rope) - Rope is a python refactoring library.
 - Type Checkers - [awesome-python-typing](https://github.com/typeddjango/awesome-python-typing)
+  - [basilisk-python](https://github.com/Nimblesite/Basilisk) - A strict-by-default type checker and language server, the only checker passing every test in the official typing conformance suite.
   - [mypy](https://github.com/python/mypy) - Check variable types during compile time.
   - [pyrefly](https://github.com/facebook/pyrefly) - A fast type checker and language server for Python.
   - [ty](https://github.com/astral-sh/ty) - An extremely fast Python type checker and language server.

--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ _Tools of static analysis, linters and code quality checkers. Also see [awesome-
 - Refactoring
   - [rope](https://github.com/python-rope/rope) - Rope is a python refactoring library.
 - Type Checkers - [awesome-python-typing](https://github.com/typeddjango/awesome-python-typing)
-  - [basilisk-python](https://github.com/Nimblesite/Basilisk) - A strict-by-default type checker and language server, the only checker passing every test in the official typing conformance suite.
+  - [basilisk-python](https://github.com/Nimblesite/Basilisk) - A strict-by-default type checker and language server with high conformance to the Python typing specification.
   - [mypy](https://github.com/python/mypy) - Check variable types during compile time.
   - [pyrefly](https://github.com/facebook/pyrefly) - A fast type checker and language server for Python.
   - [ty](https://github.com/astral-sh/ty) - An extremely fast Python type checker and language server.


### PR DESCRIPTION

Adding **[basilisk-python](https://github.com/Nimblesite/Basilisk)** under **Code Analysis → Type Checkers**, placed first alphabetically (before `mypy`).

Basilisk is a strict-by-default Python type checker and language server written in Rust. Submitting under the **Hidden Gem** criterion, with the star-count justification below.

### Why it belongs here

**It is the only type checker that passes the entire official conformance suite.** The [`python/typing` conformance results](https://github.com/python/typing/blob/main/conformance/results/results.html) — the type system's own reference scoreboard, published by the spec maintainers — currently list Basilisk as `Pass` on **141 of 141** test cases. No other checker in that table is clean:

| Checker | Pass | Partial | Unsupported |
| --- | ---: | ---: | ---: |
| **basilisk 0.27.0** | **141** | 0 | 0 |
| zuban 0.8.2 | 140 | 1 | 0 |
| pyrefly 1.1.0 | 135 | 6 | 0 |
| pyright 1.1.410 | 134 | 5 | 2 |
| pycroscope 0.4.0 | 120 | 20 | 1 |
| ty 0.0.65 | 107 | 30 | 4 |
| mypy 2.1.0 | 83 | 52 | 6 |

<sub>Counted from the linked upstream `results.html`; version labels are upstream's, not mine.</sub>

**It is not "yet another type checker."** The existing entries are checkers; Basilisk is a whole toolchain shipped as one binary — type checker, language server, debugger (DAP), and profiler — with editor extensions for VS Code, Cursor, Zed, and Neovim, and formatting/import hygiene built in. Every diagnostic links to a documentation page explaining *why* the code is wrong, and every rule is individually configurable, so teams can adopt type safety incrementally rather than flipping one global strictness switch. That is a different product shape from `mypy`, `pyrefly`, and `ty`, not a duplicate of them.

### Hidden Gem justification (< 100 stars)

Per `CONTRIBUTING.md`, projects under 100 stars need strong justification. Basilisk has **55 stars**, but:

- **Verifiable, externally-audited quality.** The 141/141 result above is not a self-reported number — it is published by the Python typing spec maintainers in their own repository, against a suite Basilisk does not control.
- **Real-world usage, not a launch-week project.** **~4,050 PyPI downloads in the last 30 days** ([pypistats](https://pypistats.org/packages/basilisk-python)) and **185 installs / 5.0★ from 4 ratings** on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Nimblesite.basilisk).
- **Solves a niche problem precisely.** Full spec conformance matters most to library authors publishing typed public APIs and to teams whose CI must agree with the specification rather than with one vendor's interpretation of it. That is a small audience relative to a general linter — which is exactly why the star count understates the project.

### Checklist against `CONTRIBUTING.md`

| Requirement | Status |
| --- | --- |
| Active — commits within 12 months | ✅ Latest commit 2026-08-03; release `v0.39.0` on 2026-08-02 |
| Stable — production-ready | ✅ 14 published PyPI releases; MIT licensed; not flagged alpha/beta |
| Documented — README with examples and use cases | ✅ [basilisk-python.dev/docs](https://www.basilisk-python.dev/docs/) plus per-diagnostic reference pages |
| Unique — adds distinct value | ✅ Only 141/141 conformant checker; checker + LSP + debugger + profiler in one binary |
| Established — repo ≥ 1 month (Hidden Gem: ≥ 3 months) | ✅ Repository created 2026-02-28 (~5 months), continuous release cadence |
| One project per PR | ✅ Single entry, single line |
| Correct category | ✅ Code Analysis → Type Checkers |
| Alphabetical ordering | ✅ `basilisk-python` precedes `mypy` |
| PyPI display name | ✅ `basilisk-python` per PyPI JSON API |
| Not a duplicate | ✅ No prior open or closed issue/PR in this repo mentions Basilisk |
| Description ends with a period | ✅ |

### One point of transparency

Quality Requirement #1 asks for >50% Python. Basilisk's implementation language is **Rust** (it ships as a compiled binary distributed on PyPI). I'm flagging this rather than glossing over it. The precedent in this list is that Python *tooling* is judged on what it does for Python developers, not on its implementation language — `ruff` and `ty` (Rust, Astral) and `pyrefly` (Rust, Meta) are all already listed, two of them in this same **Code Analysis** section. Basilisk is submitted on the same basis. Happy to withdraw if you read that rule strictly.