### PR TITLE
Add CheatGrid Python Cheat Sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1190,6 +1190,7 @@ Where to discover learning resources or new Python libraries.
 
 ### Websites
 
+- [CheatGrid Python Cheat Sheet](https://www.cheatgrid.com/programming-languages/0004-python-cheat-sheet) - Free single-page Python reference covering data types, comprehensions, decorators, context managers, asyncio, type hints, and the standard library, with a spaced-repetition flashcard deck and practice questions for the same topic.
 - [Python Developer Tooling Handbook](https://pydevtools.com/) - Comprehensive guide to modern Python developer tools covering package management, linting, type checking, testing, and more.
 
 ## Contributing


### PR DESCRIPTION
## Project

[CheatGrid Python Cheat Sheet](https://www.cheatgrid.com/programming-languages/0004-python-cheat-sheet)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

Note up front: this is an entry for `Resources > Websites`, not a Python package, so the
star-count and PyPI parts of the guidelines do not apply. I have matched the format of the
existing entry in that subsection.

It is a single-page Python reference, free and with no signup needed to read it. 26 grouped
tables covering data types, operators, string ops, slicing, control flow, functions,
comprehensions and generators, classes, dunder methods, exceptions, file I/O, imports,
built-ins, itertools, decorators, context managers, asyncio, type hints, regex, dataclasses,
enums, collections, concurrency, logging, virtualenvs and packaging.

What makes it worth a slot rather than "yet another cheat sheet": every row is a
syntax/description/example triple you can copy straight out, the modern surface is actually
covered (type hints, dataclasses, async, structural pattern matching) instead of stopping at
Python 2 era basics, and the same topic ships a spaced-repetition flashcard deck and practice
questions, so it works for revision and not only lookup.

## How It Differs

Against the usual Python cheat sheets: most are either a single screenshot-style image or a
blog post that ends at loops and functions. This is a structured, searchable page kept current
with modern syntax, and each entry carries a runnable example rather than a bare signature.
There is also a per-row explanation button that rewrites any single row in plain language with
a worked example, which is capped (100 explanations on the free account, none while logged out)
and is not the point of the page, but it is the part I have not seen elsewhere.