### PR TITLE
Add bakefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ _Libraries for debugging code._
 
 _Compile software from source code._
 
+- [bakefile](https://github.com/wislertt/bakefile) - An OOP task runner in Python. It works like a Makefile, but tasks are Python class methods, so you can inherit and reuse them across projects.
 - [bitbake](https://github.com/openembedded/bitbake) - A make-like build tool for embedded Linux.
 - [doit](https://github.com/pydoit/doit) - A task runner and build tool.
 - [invoke](https://github.com/pyinvoke/invoke) - A tool for managing shell-oriented subprocesses and organizing executable Python code into CLI-invokable tasks.


### PR DESCRIPTION
## Project

[bakefile](https://github.com/wislertt/bakefile)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

bakefile is a task runner where tasks are Python class methods instead of shell recipes, so a task library can be shared across projects and languages.

It sits at 5 stars, under the 100-star threshold for a normal entry. I know the count is low, so I've laid out the case below and would appreciate a fair look.

- **OOP, not shell recipes:** tasks are Python class methods you inherit and override, so a shared task library composes through normal Python inheritance (see Key differentiator below).
- **Python-native, not a DSL:** real type hints, type-checked args via Typer, lint/format with ruff + ty. `ctx.run()` still runs ordinary CLI commands through subprocess, so it can manage tasks for any language (Go, Rust, JS).
- **Mature, not experimental:** 67 releases over ~8 months, Apache-2.0. Declared Production/Stable in its PyPI metadata, and the core `bake` CLI has had no breaking changes in months.
- **Quality bar:** 100% test coverage across 2,130 tests, plus a clean SonarCloud quality gate for security, vulnerabilities, and maintainability (see the README badges).
- **Used in production daily:** I depend on bakefile every day. Every repo I maintain at work runs on it, Python and non-Python, in CI, shipping releases for months. To be upfront, the adoption is mostly me, not organic, but it is real and heavy: ~80K total PyPI installs and ~17K in July 2026, almost all from my own daily pipelines.
- **Modern typed stack:** Typer + Pydantic. Config is typed and validated (Pydantic `BaseSettings`), and tasks get full `--help` and shell completion.

### The problem it solves

We all have a task like this. My `bake lint` for a Python repo runs a fixed sequence:

```bash
$ bunx prettier@latest --write "**/*.{js,jsx,ts,tsx,css,json,yaml,md}"
$ uv run toml-sort --in-place pyproject.toml
$ uv run ruff format .
$ uv run ruff check --fix .
$ uv run ty check .
$ uv run deptry .
$ actionlint
```

I was pasting that into every Python repo. The prettier and actionlint lines are identical everywhere, but the middle is Python-specific, and a Rust repo swaps it for `cargo fmt` / `cargo clippy`. With bakefile that sequence lives in one base class, and each repo inherits it and overrides only the language-specific part.

## How It Differs

Task **reusability via class inheritance**. Most task runners are either a DSL (Make, Just) or flat functions with no inheritance model (invoke, doit). I searched for a runner like this for months before giving up and building bakefile, because I could not find one where tasks are class methods you inherit and override. Shared task libraries compose through normal Python inheritance, which none of the other runners do. That reuse is also how I actually maintain the project, pulling the generalizable parts of my task modules into shared, inheritable libraries that ship inside the package itself.