### PR TITLE
Add pyrig

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,7 +841,7 @@ _Useful CLI-based tools for productivity._
   - [copier](https://github.com/copier-org/copier) - A library and command-line utility for rendering projects templates.
   - [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
   - [kaydet](https://github.com/miratcan/kaydet) - Queryable personal database and terminal diary with SQLite search, tags, metadata, and AI integration via MCP.
-  - [pyrig](https://github.com/Winipedia/pyrig) - Scaffolds and rigs up a complete, fully configured Python project in one command, then keeps it in sync as pyrig evolves.
+  - [pyrig](https://github.com/Winipedia/pyrig) - A tool that standardizes and automates Python project setup, configuration, development, and maintenance.
   - [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
   - [tmuxp](https://github.com/tmux-python/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.
   - [xonsh](https://github.com/xonsh/xonsh/) - A Python-powered shell. Full-featured and cross-platform.

--- a/README.md
+++ b/README.md
@@ -841,6 +841,7 @@ _Useful CLI-based tools for productivity._
   - [copier](https://github.com/copier-org/copier) - A library and command-line utility for rendering projects templates.
   - [doitlive](https://github.com/sloria/doitlive) - A tool for live presentations in the terminal.
   - [kaydet](https://github.com/miratcan/kaydet) - Queryable personal database and terminal diary with SQLite search, tags, metadata, and AI integration via MCP.
+  - [pyrig](https://github.com/Winipedia/pyrig) - Scaffolds and rigs up a complete, fully configured Python project in one command, then keeps it in sync as pyrig evolves.
   - [thefuck](https://github.com/nvbn/thefuck) - Correcting your previous console command.
   - [tmuxp](https://github.com/tmux-python/tmuxp) - A [tmux](https://github.com/tmux/tmux) session manager.
   - [xonsh](https://github.com/xonsh/xonsh/) - A Python-powered shell. Full-featured and cross-platform.


### PR DESCRIPTION
## Project

[pyrig](https://github.com/Winipedia/pyrig)

## Checklist

- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [project-name](url) - Description ending with period.`
- [x] Description is concise and short

## Why This Project Is Awesome

Which criterion does it meet? (pick one)

- [ ] **Industry Standard** - The go-to tool for a specific use case
- [ ] **Rising Star** - 5000+ stars in < 2 years, significant adoption
- [x] **Hidden Gem** - Exceptional quality, solves niche problems elegantly

Explain:

pyrig scaffolds a complete, fully configured, and working Python project with a single command — dependency management, linting, type checking, testing, pre-commit hooks, CI/CD, and docs all wired up and functional from the start. Unlike a one-time generator, it stays involved after setup: running `pyrig sync` keeps a project's tooling and structure current as pyrig itself evolves. It's built around a strict philosophy of shipping one opinionated, batteries-included default per concern rather than exposing a grid of configurable options, which keeps setup and maintenance genuinely simple rather than just configurable. However at the same time it offers full customization via a plugin system based on subclasses where you can adjust behavior and settings via overriding methods in a subclass.

## How It Differs

If similar entries exist, what makes this one unique?

`cookiecutter` and `copier` render a project template once at creation time — after that, the generated project is on its own. pyrig instead keeps ownership of a project's tooling and configuration over its lifetime: `pyrig sync` re-applies and updates the scaffolding as the project and pyrig itself evolve, rather than leaving you to manually maintain what was templated. It also goes further than templating alone, wiring up CI/CD, testing infrastructure, and dependency/version management as part of the same opinionated system, instead of a config file you customize yourself.
