### PR TITLE
Add voicute — offline keyword spotting and wake word detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [SenseVoice](https://github.com/FunAudioLLM/SenseVoice) - A multilingual speech understanding model for speech recognition, language identification, emotion recognition, and audio event detection.
   - [vibevoice](https://github.com/microsoft/VibeVoice) - A family of open-source voice AI models from Microsoft for text-to-speech and long-form speech recognition.
   - [voxcpm](https://github.com/OpenBMB/VoxCPM) - A tokenizer-free text-to-speech foundation model for multilingual speech generation and voice cloning.
+  - [voicute](https://github.com/voicute/onnx-wakeword) - Offline keyword spotting and wake word detection with ONNX Runtime, multi-keyword support, and 5-layer anti-false-trigger filtering.
 
 ### Deep Learning
 


### PR DESCRIPTION
Adds [voicute](https://github.com/voicute/onnx-wakeword) to the Speech section.

voicute is an open-source (MIT) Python library for offline keyword spotting and wake word detection:
- Pure Python + ONNX Runtime, no cloud dependency
- Multi-keyword support with a single model
- 5-layer anti-false-trigger filtering
- Cross-platform: ESP32, Android, Web, Linux, Windows

The project includes a Wyoming protocol service for Home Assistant voice pipeline integration.