### PR TITLE
Add peek — htop for codebases to Code Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ _Tools of static analysis, linters and code quality checkers. Also see [awesome-
 
 - Code Analysis
   - [code2flow](https://github.com/scottrogowski/code2flow) - Turn your Python and JavaScript code into DOT flowcharts.
+  - [peek](https://github.com/hariomlohardev/peek) - The htop for codebases — understand any repo in 5 seconds. Python + Rich + Textual, `pip install peek-code && peek .`, PageRank-style `Start Here` ranking.
   - [prospector](https://github.com/prospector-dev/prospector) - A tool to analyze Python code.
   - [repowise](https://github.com/repowise-dev/repowise) - Codebase intelligence that indexes repos into dependency graphs, git history, and auto-generated docs with dead code detection.
   - [vulture](https://github.com/jendrikseipp/vulture) - A tool for finding and analyzing dead Python code.


### PR DESCRIPTION
### What

Adds [peek](https://github.com/hariomlohardev/peek) — *the htop for codebases* — to **Code Analysis** under Developer Tools.

- **One-liner:** `pip install peek-code && peek .` → 5 seconds to see languages, stack, `Start Here` ranked, and import graph
- **Stack:** Python + Rich + Textual, `PageRank` + `ast` import graph, `pip install` <10s, offline, never crashes
- **Why it fits:** It’s a static analysis & codebase intelligence tool (like `code2flow`/`vulture`) but with a ranked `Start Here` and interactive TUI — not just a linter.

### Checklist

- [x] One-line description follows the list’s style (`Name - Description.`)
- [x] Link is to the GitHub repo (`hariomlohardev/peek`)
- [x] Fits **Code Analysis** (also see `awesome-static-analysis`)
- [x] No affiliation — just a useful tool for the list

Thanks for considering! :sparkles:

*P.S. Live at https://github.com/hariomlohardev/peek — 146 tests, 10 themes, `peek-code` on PyPI.*