### PR TITLE
Add SpotiFLAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,6 +814,7 @@ _Useful CLI-based tools._
   - [litecli](https://github.com/dbcli/litecli) - SQLite CLI with autocompletion and syntax highlighting.
   - [iredis](https://github.com/laixintao/iredis) - Redis CLI with autocompletion and syntax highlighting.
 - Downloaders
+  - [SpotiFLAC](https://github.com/BartolomeoRusso9/SpotiFLAC-Module-Version) - Download Spotify tracks in true lossless FLAC from Tidal, Qobuz, Amazon Music and Deezer with sync/async Python APIs.
   - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A command-line program to download videos from YouTube and other video sites, a fork of youtube-dl.
 - HTTP Clients
   - [httpie](https://github.com/httpie/cli) - A command line HTTP client, a user-friendly cURL replacement.

--- a/README.md
+++ b/README.md
@@ -814,7 +814,6 @@ _Useful CLI-based tools._
   - [litecli](https://github.com/dbcli/litecli) - SQLite CLI with autocompletion and syntax highlighting.
   - [iredis](https://github.com/laixintao/iredis) - Redis CLI with autocompletion and syntax highlighting.
 - Downloaders
-  - [SpotiFLAC](https://github.com/BartolomeoRusso9/SpotiFLAC-Module-Version) - Download Spotify tracks in true lossless FLAC from Tidal, Qobuz, Amazon Music and Deezer with sync/async Python APIs.
   - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A command-line program to download videos from YouTube and other video sites, a fork of youtube-dl.
 - HTTP Clients
   - [httpie](https://github.com/httpie/cli) - A command line HTTP client, a user-friendly cURL replacement.

--- a/README.md
+++ b/README.md
@@ -962,6 +962,7 @@ _Libraries for manipulating audio, video, and their metadata._
   - [mutagen](https://github.com/quodlibet/mutagen) - A Python module to handle audio metadata.
   - [tinytag](https://github.com/tinytag/tinytag) - A library for reading music meta data of MP3, OGG, FLAC and Wave files.
   - [beets](https://github.com/beetbox/beets) - A music library manager and [MusicBrainz](https://musicbrainz.org/) tagger.
+  - [SpotiFLAC](https://github.com/BartolomeoRusso9/SpotiFLAC-Module-Version) - Resolves track metadata from Spotify, Tidal, Apple Music, SoundCloud, YouTube and Pandora links and enriches it via MusicBrainz, with sync/async Python APIs and a pluggable extension system for provider-based audio retrieval.
 
 ### Game Development
 


### PR DESCRIPTION
## Project
[SpotiFLAC](https://github.com/BartolomeoRusso9/SpotiFLAC-Module-Version)
 
## Checklist
- [x] I read CONTRIBUTING.md - awesome-python is a shortlist, not a catalog
- [x] One project per PR
- [x] PR title format: `Add SpotiFLAC`
- [x] Entry format: `- [SpotiFLAC](https://github.com/BartolomeoRusso9/SpotiFLAC-Module-Version) - Description ending with period.`
- [x] Display name is the PyPI package name
- [x] Placed in an existing use case (Audio & Video Processing > Metadata)
- [x] Meets all Quality Requirements: active, stable, documented, at least 1 month old
## Which Tier
- [x] **Challenger** - not yet the obvious choice, but a credible successor to one. Give adoption-trajectory evidence, not popularity alone.
Explain:
Within "Metadata," `beets` and `mutagen`/`tinytag` cover local-library tagging and metadata reading/writing. SpotiFLAC covers an adjacent gap: resolving canonical track metadata from a streaming link (Spotify, Tidal, Apple Music, SoundCloud, YouTube, Pandora) and enriching it via MusicBrainz — with sync/async Python APIs, a CLI wizard, and a GUI built on top. Out of the box it ships with **no built-in download provider**: actual audio retrieval is delegated to JavaScript or Python extensions that the user finds, reviews, and installs from a registry of their own choosing, a deliberate design that avoids bundling any single streaming service's client and lets providers be swapped without a package release. It's the most actively maintained project of its kind (1,000+ commits, 186 stars, published on PyPI), and has companion desktop and mobile apps built by other maintainers on the same extension model — evidence of real adoption of the underlying architecture.
 
## Displacement
The "Metadata" subcategory isn't at its cap for this use case — `beets`, `mutagen`, and `tinytag` all operate on files already on disk. None of them resolve metadata from a streaming-service link or orchestrate retrieval through a pluggable provider system, so SpotiFLAC doesn't compete with them for the same job; it fills a use case they don't cover.