### PR TITLE
Add Nudge - typed programming language for LLM agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [langgraph](https://github.com/langchain-ai/langgraph) - Low-level orchestration framework for building stateful, long-running LLM agents.
   - [crewai](https://github.com/crewAIInc/crewAI) - A framework for orchestrating role-playing autonomous AI agents for collaborative task solving.
   - [pydantic-ai](https://github.com/pydantic/pydantic-ai) - A Python agent framework for building generative AI applications with structured schemas.
+  - [Nudge](https://github.com/NekomyaDev/nudge) - A typed, replayable, budget-aware programming language for LLM agents. Compiles to Python & TypeScript.
 - Vendor Agent SDKs
   - [openai-agents](https://github.com/openai/openai-agents-python) - OpenAI's framework for building and managing AI agents.
   - [claude-agent-sdk](https://github.com/anthropics/claude-agent-sdk-python) - Anthropic's Python SDK for building AI agents on Claude Code's harness — custom tools, in-process MCP servers, hooks.


### PR DESCRIPTION
## What

Added [Nudge](https://github.com/NekomyaDev/nudge) to the AI and Agents / Orchestration section.

## Why

Nudge is a typed, replayable, budget-aware programming language for LLM agents. It compiles to Python & TypeScript and features:

- Typed LLM calls with schema validation
- Deterministic replay and trace-based testing
- Budget contracts for cost control
- Effect system (pure / LLM / Tool / IO)
- Native parallelism (par map/race/all)
- Zero dependencies, single Rust binary

## Links

- GitHub: https://github.com/NekomyaDev/nudge
- VS Code Extension: https://marketplace.visualstudio.com/items?itemName=Nekomya.nudge-lang