### PR TITLE
Add zapros

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ _Libraries for working with HTTP._
   - [aiohttp](https://github.com/aio-libs/aiohttp) - Asynchronous HTTP client/server framework for asyncio and Python.
   - [urllib3](https://github.com/urllib3/urllib3) - A HTTP library with thread-safe connection pooling, file post support, sanity friendly.
   - [httpx2](https://github.com/pydantic/httpx2) - HTTP/1.1 and HTTP/2 client with sync and async APIs, maintained by Pydantic ([httpx](https://github.com/encode/httpx) fork).
+  - [zapros](https://github.com/kap-sh/zapros) - Modern and extensible HTTP client with sync and async APIs, retries, caching, and WebSockets built in.
 - URL Manipulation
   - [yarl](https://github.com/aio-libs/yarl) - Yet another URL library.
   - [httpx.URL](https://www.python-httpx.org/api/) - The immutable URL class bundled with HTTPX.


### PR DESCRIPTION
## Project

[zapros](https://github.com/kap-sh/zapros) - Modern and extensible HTTP client with sync and async APIs, retries, caching, and WebSockets built in.

## Checklist

- [x] I read [CONTRIBUTING.md](https://github.com/vinta/awesome-python/blob/master/CONTRIBUTING.md) - awesome-python is a shortlist, not a catalog
- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [pypi-name](https://github.com/owner/repo) - Description ending with period.`
- [x] Display name is the PyPI package name
- [x] Placed in an existing use case (new sections and subcategories are maintainer-only)
- [x] Meets all Quality Requirements: active, stable, documented, at least 1 month old

## Which Tier

Pick one:

- [ ] **Obvious choice** - a tool an experienced Python developer would name when asked "what do I use for this?"
- [x] **Challenger** - not yet the obvious choice, but a credible successor to one. Give adoption-trajectory evidence, not popularity alone.

Explain:

zapros is an HTTP client with sync and async APIs and retries, caching, mocking, HTTP cassettes, and a WebSocket client built in, designed to run on any I/O (Python, Rust, or the browser's network stack), written by one of the httpx maintainers. First release March 2026, 20 releases since (v0.16.0, Jul 2026), 27K downloads/month (pypistats), 212 stars. Placed last in the Clients challenger tier per downloads ordering, behind urllib3 and httpx2.

## Displacement

None proposed — added at the end of Clients as a third challenger, leaving the existing five untouched. Happy to name a displacement if the maintainer prefers to hold the cap
