### PR TITLE
Add rfc5322 (strict RFC 5322 email-address parser) to Email

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ _Libraries to automate web scraping and extract web content._
 _Libraries for sending and parsing email, and mail server management._
 
 - [yagmail](https://github.com/kootenpv/yagmail) - Yet another Gmail/SMTP client.
+- [rfc5322](https://github.com/AH64-dll/rfc5322) - Zero-dependency RFC 5322 email-address parser with strict and permissive modes.
 
 **Database & Storage**
 


### PR DESCRIPTION
Adds [rfc5322](https://github.com/AH64-dll/rfc5322) to the **Email** section.

rfc5322 is a zero-dependency Python library implementing the full RFC 5322 (Internet Message Format) address grammar with strict and permissive modes; ships py.typed; 100 passing tests; MIT licensed.

The section description reads "Libraries for sending and parsing email" - this adds a dedicated address parser.

Entry placed alphabetically before yagmail, matching section style.