### PR TITLE
Add pyrift — static analyser for CPython/PyPy behaviour differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,10 +604,11 @@ _Interactive Python interpreters (REPL)._
 _Tools of static analysis, linters and code quality checkers. Also see [awesome-static-analysis](https://github.com/analysis-tools-dev/static-analysis)._
 
 - Code Analysis
-  - [vulture](https://github.com/jendrikseipp/vulture) - A tool for finding and analyzing dead Python code.
-  - [prospector](https://github.com/prospector-dev/prospector) - A tool to analyze Python code.
-  - [repowise](https://github.com/repowise-dev/repowise) - Codebase intelligence that indexes repos into dependency graphs, git history, and auto-generated docs with dead code detection.
   - [complexipy](https://github.com/rohaquinlop/complexipy) - Cognitive complexity analysis for Python code, written in Rust.
+  - [prospector](https://github.com/prospector-dev/prospector) - A tool to analyze Python code.
+  - [pyrift](https://github.com/BHUVANSH855/pyrift) - Detects silent Python behaviour differences across CPython versions and PyPy that linters and type checkers miss.
+  - [repowise](https://github.com/repowise-dev/repowise) - Codebase intelligence that indexes repos into dependency graphs, git history, and auto-generated docs with dead code detection.
+  - [vulture](https://github.com/jendrikseipp/vulture) - A tool for finding and analyzing dead Python code.
 - Git Hooks
   - [pre-commit](https://github.com/pre-commit/pre-commit) - A framework for managing and maintaining multi-language pre-commit hooks.
 - Linters and Formatters


### PR DESCRIPTION
## Project
[pyrift](https://github.com/BHUVANSH855/pyrift)

## Checklist
- [x] I read [CONTRIBUTING.md](https://github.com/vinta/awesome-python/blob/master/CONTRIBUTING.md) - awesome-python is a shortlist, not a catalog
- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [pypi-name](https://github.com/owner/repo) - Description ending with period.`
- [x] Display name is the PyPI package name
- [x] Placed in an existing use case (new sections and subcategories are maintainer-only)
- [x] Meets all Quality Requirements: active, stable, documented, at least 1 month old

## Which Tier
- [x] **Challenger** - not yet the obvious choice, but a credible successor to one. Give adoption-trajectory evidence, not popularity alone.

Explain:
pyrift fills a gap that no existing Code Analysis tool covers — silent 
runtime behaviour differences across CPython versions and between CPython 
and PyPy. Tools like pylint, ruff, mypy, and bandit all operate on syntax 
and types. pyrift operates on runtime semantics: deprecated APIs, removed 
modules, GC timing differences, and version-specific stdlib gaps.

It was released in August 2026, reached v0.7.0 within days, has 90 rules, 
392 tests, zero dependencies, and is already announced on Python Discord, 
Python Discourse, and the PyPy mailing list. The library solves a real 
problem — Python version upgrades and CPython/PyPy compatibility — that 
developers currently handle manually or not at all.

## Displacement
No displacement needed. pyrift occupies a unique position in the Code 
Analysis section — it is the only tool focused on runtime behaviour 
differences rather than syntax, style, or types. It complements rather 
than replaces existing entries.