### PR TITLE
Add axolotl

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [diffusers](https://github.com/huggingface/diffusers) - A library that provides pre-trained diffusion models for generating and editing images, audio, and video.
 - Fine-tuning
   - [unsloth](https://github.com/unslothai/unsloth) - A library for faster LLM fine-tuning and training with reduced memory usage.
+  - [axolotl](https://github.com/axolotl-ai-cloud/axolotl) - A framework for fine-tuning and post-training large language models.
 - Speech
   - [openai-whisper](https://github.com/openai/whisper) - A general-purpose automatic speech recognition model trained on 680k hours of multilingual and multitask supervised data.
   - [funasr](https://github.com/modelscope/FunASR) - Industrial-grade speech recognition toolkit with 170x realtime speed, 50+ languages, speaker diarization, and emotion detection.


### PR DESCRIPTION
## Project

[axolotl](https://github.com/axolotl-ai-cloud/axolotl)

## Checklist

- [X] I read [CONTRIBUTING.md](https://github.com/vinta/awesome-python/blob/master/CONTRIBUTING.md) - awesome-python is a shortlist, not a catalog
- [X] One project per PR
- [X] PR title format: `Add project-name`
- [X] Entry format: `- [pypi-name](https://github.com/owner/repo) - Description ending with period.`
- [X] Display name is the PyPI package name
- [X] Placed in an existing use case (new sections and subcategories are maintainer-only)
- [X] Meets all Quality Requirements: active, stable, documented, at least 1 month old

## Which Tier

Pick one:

- [X] **Obvious choice** - a tool an experienced Python developer would name when asked "what do I use for this?"
- [ ] **Challenger** - not yet the obvious choice, but a credible successor to one. Give adoption-trajectory evidence, not popularity alone.

Explain:

## Obvious choice

Axolotl is one of the standard open-source fine-tuning and post-training frameworks in the Python LLM ecosystem (12.4k+ GitHub stars, widely adopted across major open-source model releases). It provides unified support for leading architectures (Llama, Mistral, Gemma, Qwen, DeepSeek) with FSDP, DeepSpeed, LoRA/QLoRA, and alignment techniques (DPO, IPO, KTO, ORPO, GRPO). The **Fine-tuning** subcategory currently only lists `unsloth`, making `axolotl` an obvious addition.