### PR TITLE
Add minibot

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ _Libraries for building AI applications, LLM integrations, and autonomous agents
   - [claude-agent-sdk](https://github.com/anthropics/claude-agent-sdk-python) - Anthropic's Python SDK for building AI agents on Claude Code's harness — custom tools, in-process MCP servers, hooks.
 - Personal Assistants
   - [hermes-agent](https://github.com/nousresearch/hermes-agent) - An adaptive personal AI assistant that grows with you.
+  - [minibot](https://github.com/sonic182/minibot) - Lightweight self-hosted personal AI assistant for Telegram with tools, memory, scheduling, and Python extensions.
 - Prompt Optimization
   - [dspy](https://github.com/stanfordnlp/dspy) - A framework for programming, not prompting, language models.
 - Data Layer


### PR DESCRIPTION
## Project

[minibot](https://github.com/sonic182/minibot)

## Checklist

- [x] I read [CONTRIBUTING.md](https://github.com/vinta/awesome-python/blob/master/CONTRIBUTING.md) - awesome-python is a shortlist, not a catalog
- [x] One project per PR
- [x] PR title format: `Add project-name`
- [x] Entry format: `- [pypi-name](https://github.com/owner/repo) - Description ending with period.`
- [x] Display name is the PyPI package name
- [x] Placed in an existing use case (AI and Agents > Personal Assistants)
- [x] Meets all Quality Requirements: active, stable, documented, at least 1 month old

## Which Tier

Pick one:

- [ ] **Obvious choice** - a tool an experienced Python developer would name when asked "what do I use for this?"
- [x] **Challenger** - not yet the obvious choice, but a credible successor to one. Give adoption-trajectory evidence, not popularity alone.

Explain:

Personal Assistants currently lists one entry, hermes-agent, which is a conversational assistant you talk to. minibot covers the self-hosted, operational end of the same use case: an always-on instance you run yourself, where chats, memory, and scheduled prompts stay on your infrastructure rather than a vendor's.

The distinguishing property is weight. A default install pulls pydantic, sqlalchemy with aiosqlite, aiosonic, llm-async, rich, selectolax, croniter, and tomlkit, and nothing else. There is no torch, no langchain, and no llama-index in the dependency tree. The MCP bridge is a self-contained JSON-RPC client that does not require the mcp package at runtime. Everything heavy is opt-in: Telegram, speech-to-text, RabbitMQ, and PDF parsing are optional extras, and the RAG stack is deliberately left unmanaged so torch and sentence-transformers are installed only by users who actually enable it. Persistence is SQLite by default. The result is a personal assistant that runs on a small always-on box without dragging in an ML training stack.

What it does within this use case: Telegram-first delivery with chat and user allowlists in long-polling or webhook mode; scheduled prompts with one-shot, fixed-interval, and cron recurrence persisted in SQLite; provider-agnostic LLM access via llm-async covering openai, openai_responses, and openrouter; MCP server bridges alongside a Python extension API for custom tools, event subscribers, background services, and channels; optional Qdrant-backed RAG over local documents; async task workers for long-running jobs; and Docker plus docker-compose deployment with structured logfmt logs.

Adoption trajectory: ~630 PyPI downloads per month, released steadily since February 2026, currently at v0.11.0 with an active release cadence and full documentation at https://sonic182.github.io/minibot.

## Displacement

Not applicable. Personal Assistants holds 1 of 5 permitted entries, so no displacement is required.